### PR TITLE
send invoices as presentation

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": false,
+    "singleQuote": true
+}

--- a/modules/contacts_in.js
+++ b/modules/contacts_in.js
@@ -22,19 +22,18 @@
 
 // Import Libraries
 
-const uuidv1				= require('uuid').v1
+const uuidv1 = require("uuid").v1;
 
 // Database
 
-const db					= require('../database.js');
+const db = require("../database.js");
 
 /*
  * Helper functions
  */
 
-const checkInviteCodeValid = async(local_uuid, invite_code) => {
-
-	const sql = `
+const checkInviteCodeValid = async (local_uuid, invite_code) => {
+  const sql = `
 		SELECT
 			invite_code,
 			rel_buyer,
@@ -50,32 +49,27 @@ const checkInviteCodeValid = async(local_uuid, invite_code) => {
 			invite_code = ?
 	`;
 
-	const args = [
-		local_uuid,
-		invite_code
-	];
+  const args = [local_uuid, invite_code];
 
-	const row = await db.selectOne(sql, args);
-	console.log(row);
-	if(!row) {
-		return [ null, new Error('Invite Code not valid')];
-	}
+  const row = await db.selectOne(sql, args);
+  console.log(row);
+  if (!row) {
+    return [null, new Error("Invite Code not valid")];
+  }
 
-	const { use_count, max_count } = row;
-	if(use_count >= max_count) {
-		return [ null, new Error('Invite Code has been redeemed')];
-	}
-	
-	return [ row, null ];
+  const { use_count, max_count } = row;
+  if (use_count >= max_count) {
+    return [null, new Error("Invite Code has been redeemed")];
+  }
 
-}
+  return [row, null];
+};
 
 /*
  * checkForExistingContact
  */
 const checkForExistingContact = async (local_uuid, remote_uuid) => {
-
-	const sql = `
+  const sql = `
 		SELECT
 			COUNT(*) AS num
 		FROM
@@ -88,25 +82,19 @@ const checkForExistingContact = async (local_uuid, remote_uuid) => {
 			removed_on IS NULL
 	`;
 
-	const args = [
-		local_uuid,
-		remote_uuid
-	];
+  const args = [local_uuid, remote_uuid];
 
-
-	const { num } = await db.selectOne(sql, args);
-	return num;
-
-}
+  const { num } = await db.selectOne(sql, args);
+  return num;
+};
 
 /*
  * insertNewContact
  */
 const insertNewContact = async (invite_code, local_member_uuid, credential) => {
+  // Get local username
 
-	// Get local username
-
-	const mySql = `
+  const mySql = `
 		SELECT
 			membername AS local_member_name
 		FROM
@@ -115,60 +103,58 @@ const insertNewContact = async (invite_code, local_member_uuid, credential) => {
 			member_uuid = ?
 	`;
 
-	const myArgs = [
-		local_member_uuid
-	];
+  const myArgs = [local_member_uuid];
 
-	let row;
-	try {
-		row = await db.selectOne(mySql, myArgs);
-	} catch(err) {
-		return [ null, err ];
-	}
-	
-	const { local_member_name } = row;
+  let row;
+  try {
+    row = await db.selectOne(mySql, myArgs);
+  } catch (err) {
+    return [null, err];
+  }
 
-	// Get Information from Business Card
+  const { local_member_name } = row;
 
-	const [ link ] = credential.relatedLink.filter( (link) => {
-		return link.linkRelationship !== 'Invite';
-	});
+  // Get Information from Business Card
 
-	const relation = {
-		local_to_remote: 0,
-		remote_to_local: 0
-	};
+  const [link] = credential.relatedLink.filter((link) => {
+    return link.linkRelationship !== "Invite";
+  });
 
-	switch(link.linkRelationship) {
-	case 'Partner':
-		relation.local_to_remote = 1;
-		relation.remote_to_local = 1;
-		break;
-	case 'Buyer':
-		relation.local_to_remote = 1;
-		break;
-	case 'Seller':
-		relation.remote_to_local = 1;
-		break;
-	}
+  const relation = {
+    local_to_remote: 0,
+    remote_to_local: 0,
+  };
 
-	const remote_origin = link.target.replace('/api/presentations/available', '')
-	const remote_member_uuid = credential.issuer.id;
-	const remote_member_name = credential.issuer.name;
+  switch (link.linkRelationship) {
+    case "Partner":
+      relation.local_to_remote = 1;
+      relation.remote_to_local = 1;
+      break;
+    case "Buyer":
+      relation.local_to_remote = 1;
+      break;
+    case "Seller":
+      relation.remote_to_local = 1;
+      break;
+  }
 
-	const remote_organization = {
-		name: credential.credentialSubject.name,
-		postcode: credential.credentialSubject.address.postalCode,
-		address: credential.credentialSubject.address.streetAddress,
-		building: credential.credentialSubject.address.crossStreet,
-		department: credential.credentialSubject.department,
-		city: credential.credentialSubject.address.addressLocality,
-		state: credential.credentialSubject.address.addressRegion,
-		country: credential.credentialSubject.address.addressCountry,
-		taxId: credential.credentialSubject.taxId
-	}
+  const remote_origin = link.target.replace("/api/presentations/available", "");
+  const remote_member_uuid = credential.issuer.id;
+  const remote_member_name = credential.issuer.name;
 
-	const sql = `
+  const remote_organization = {
+    name: credential.credentialSubject.name,
+    postcode: credential.credentialSubject.address.postalCode,
+    address: credential.credentialSubject.address.streetAddress,
+    building: credential.credentialSubject.address.crossStreet,
+    department: credential.credentialSubject.department,
+    city: credential.credentialSubject.address.addressLocality,
+    state: credential.credentialSubject.address.addressRegion,
+    country: credential.credentialSubject.address.addressCountry,
+    taxId: credential.credentialSubject.taxId,
+  };
+
+  const sql = `
 		INSERT INTO contacts (
 			_id,
 			invite_code,
@@ -194,81 +180,87 @@ const insertNewContact = async (invite_code, local_member_uuid, credential) => {
 		)
 	`;
 
-	const _id = uuidv1();
+  const _id = uuidv1();
 
-	const args = [
-		_id,
-		invite_code,
-		local_member_uuid,
-		local_member_name,
-		remote_origin,
-		remote_member_uuid,
-		remote_member_name,
-		JSON.stringify(remote_organization),
-		relation.local_to_remote,
-		relation.remote_to_local
-	];
-	
-	try {
-		await db.insert(sql, args);
-	} catch(err) {
-		return [ null, err ];
-	}
-	
-	// TODO: update use_count on invite table
+  const args = [
+    _id,
+    invite_code,
+    local_member_uuid,
+    local_member_name,
+    remote_origin,
+    remote_member_uuid,
+    remote_member_name,
+    JSON.stringify(remote_organization),
+    relation.local_to_remote,
+    relation.remote_to_local,
+  ];
 
-	return [ true, null ];
+  try {
+    await db.insert(sql, args);
+  } catch (err) {
+    return [null, err];
+  }
 
-}
+  // TODO: update use_count on invite table
+
+  return [true, null];
+};
 
 //------------------------------ define endpoints ------------------------------
-
 
 /*
  * contactRequest
  */
 
 const handleContactRequest = async (body) => {
+  console.log("--- Handle Contact Request ---");
 
-	console.log('--- Handle Contact Request ---');
-	
-	// 1.
-	// First we see if the invite code is still valid
-	
-	const invite_code = body.id.split(':').pop();
-	const [ linkRelationship ] = body.relatedLink.filter( (link) => {
-		return link.linkRelationship === 'Invite';
-	});
-	const local_member_uuid = linkRelationship.target;
+  // 1.
+  // First we see if the invite code is still valid
 
+  const invite_code = body.id.split(":").pop();
+  const [linkRelationship] = body.relatedLink.filter((link) => {
+    return link.linkRelationship === "Invite";
+  });
+  const local_member_uuid = linkRelationship.target;
 
-	const [ invite, inviteEr ] = await checkInviteCodeValid(local_member_uuid, invite_code);
-	if(inviteEr) {
-		return [ 400, 'invite code invalid' ];
-	}
+  const [invite, inviteEr] = await checkInviteCodeValid(
+    local_member_uuid,
+    invite_code
+  );
+  if (inviteEr) {
+    return [400, "invite code invalid"];
+  }
 
-	// 2.
-	// Then we see if the contact already exists
-	
-	const remote_member_uuid = body.issuer.id;
-	const exists = await checkForExistingContact(local_member_uuid, remote_member_uuid);
-	if(exists) {
-		return [ 400, 'contact already exists' ];
-	}
+  // 2.
+  // Then we see if the contact already exists
 
-	// 3.
-	// Then we try to insert the contact
-	
-	const [ created, createErr ] = await insertNewContact(invite_code, local_member_uuid, body);
-	if(createErr) {
-		return [ 400, 'could not create contact' ];
-	}
+  const remote_member_uuid = body.issuer.id;
+  const exists = await checkForExistingContact(
+    local_member_uuid,
+    remote_member_uuid
+  );
+  if (exists) {
+    return [400, "contact already exists"];
+  }
 
-	// Then we return a confirmation status
-	
-	return [ 200, 'contact created' ];
-}
+  // 3.
+  // Then we try to insert the contact
 
-module.exports = { 
-	handleContactRequest 
+  const [created, createErr] = await insertNewContact(
+    invite_code,
+    local_member_uuid,
+    body
+  );
+  if (createErr) {
+    return [400, "could not create contact"];
+  }
+
+  // Then we return a confirmation status
+
+  return [200, "contact created"];
+};
+
+module.exports = {
+  handleContactRequest,
 };

--- a/modules/invoices_in.js
+++ b/modules/invoices_in.js
@@ -1,0 +1,162 @@
+/**
+
+ Apache-2.0 License
+ Copyright 2020 - 2022 Web Service Development Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Author: Ogawa Kousei (kogawa@wsd.co.jp)
+    
+**/
+
+"use strict";
+
+// Table Name
+const BUYER__DOCUMENT = "buyer_document";
+const BUYER__STATUS = "buyer_status";
+const CONTACTS = "contacts";
+
+const sub = require("../routes/invoice_sub.js");
+const tran = require("../routes/invoice_sub_transaction.js");
+
+const handleIncomingInvoice = async (invoiceCert, res) => {
+  //console.log("/buyerToSend");
+
+  const { credentialSubject } = invoiceCert;
+  const { totalPaymentDue } = credentialSubject;
+  const document_uuid = credentialSubject.identifier;
+  const seller_uuid = credentialSubject.seller.id;
+  const buyer_uuid = credentialSubject.buyer.id;
+  const document_json = JSON.stringify(invoiceCert);
+
+  const status = {
+    document_uuid,
+    document_type: "invoice",
+    document_number: credentialSubject.invoiceNumber,
+    seller_uuid,
+    seller_membername: credentialSubject.seller.contactPoint.split("@").shift(),
+    seller_organization: credentialSubject.seller.name,
+    seller_archived: 0,
+    seller_last_action: new Date(),
+    buyer_uuid,
+    buyer_membername: credentialSubject.buyer.contactPoint.split("@").shift(),
+    buyer_organization: credentialSubject.buyer.name,
+    buyer_archived: 0,
+    buyer_last_action: new Date("0000-00-00 00:00:00"),
+    created_from: null,
+    root_document: null,
+    created_on: new Date(credentialSubject.invoiceDate),
+    removed_on: null,
+    opened: 0,
+    subject_line: credentialSubject.customerReferenceNumber,
+    due_by: new Date(credentialSubject.purchaseDate),
+    amount_due: `${totalPaymentDue.price} ${totalPaymentDue.priceCurrency}`,
+    document_folder: "sent",
+  };
+
+  //console.log(document);
+  let errno, code;
+
+  // 1.
+
+  //console.log("/buyerToSend:"+CONTACTS+":"+ seller_uuid+":"+ buyer_uuid);
+
+  // 2.
+  // Second we check to see if there is any contact information
+  const [_2, err2] = await sub.getSellerHost(CONTACTS, seller_uuid, buyer_uuid);
+
+  if (err2) {
+    console.log("/buyerToSend:err 2");
+    return res.status(400).json(err2);
+  }
+
+  // 3.
+  // Then we check to see if there is any data already registered
+  //
+  const [_3, err3] = await sub.checkForExistingDocument(
+    BUYER__DOCUMENT,
+    document_uuid
+  );
+
+  if (err3) {
+    console.log("/buyerToSend:err 3");
+    return res.status(400).json(err3);
+  }
+
+  /*
+   * Convert time format from ISO format to Date format.
+   */
+  // 4.
+  //
+  status.due_by = new Date(Date.parse(status.due_by));
+
+  // 5.
+  // begin Transaction
+  //
+  const [conn, _5] = await tran.connection();
+  await tran.beginTransaction(conn);
+
+  // 6.
+  const [_6, err6] = await tran.insertDocument(
+    conn,
+    BUYER__DOCUMENT,
+    status,
+    document_json
+  );
+
+  if (err6) {
+    console.log("/buyerToSend:err 6");
+    errno = 6;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err6, errno));
+  }
+
+  // 7.
+  //
+  const [_7, err7] = await tran.insertStatus(conn, BUYER__STATUS, status);
+
+  if (err7) {
+    console.log("/buyerToSend:err 7");
+    errno = 7;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err7, errno));
+  }
+
+  // 8.
+  // commit
+  //
+  const [_8, err8] = await tran.commit(conn);
+
+  if (err8) {
+    console.log("/buyerToSend:err 8");
+    errno = 8;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err8, errno));
+  }
+
+  // 9.
+  //
+  conn.end();
+  res.status(200).end("accepted");
+
+  console.log("/buyerToSend accepted");
+};
+
+module.exports = {
+  handleIncomingInvoice,
+};

--- a/modules/invoices_in.js
+++ b/modules/invoices_in.js
@@ -18,145 +18,153 @@
     
 **/
 
-"use strict";
+'use strict'
 
 // Table Name
-const BUYER__DOCUMENT = "buyer_document";
-const BUYER__STATUS = "buyer_status";
-const CONTACTS = "contacts";
+const BUYER__DOCUMENT = 'buyer_document'
+const BUYER__STATUS = 'buyer_status'
+const CONTACTS = 'contacts'
 
-const sub = require("../routes/invoice_sub.js");
-const tran = require("../routes/invoice_sub_transaction.js");
+const sub = require('../routes/invoice_sub.js')
+const tran = require('../routes/invoice_sub_transaction.js')
 
 const handleIncomingInvoice = async (invoiceCert, res) => {
-  //console.log("/buyerToSend");
+    //console.log("/buyerToSend");
 
-  const { credentialSubject } = invoiceCert;
-  const { totalPaymentDue } = credentialSubject;
-  const document_uuid = credentialSubject.identifier;
-  const seller_uuid = credentialSubject.seller.id;
-  const buyer_uuid = credentialSubject.buyer.id;
-  const document_json = JSON.stringify(invoiceCert);
+    const { credentialSubject } = invoiceCert
+    const { totalPaymentDue } = credentialSubject
+    const document_uuid = credentialSubject.identifier
+    const seller_uuid = credentialSubject.seller.id
+    const buyer_uuid = credentialSubject.buyer.id
+    const document_json = JSON.stringify(invoiceCert)
 
-  const status = {
-    document_uuid,
-    document_type: "invoice",
-    document_number: credentialSubject.invoiceNumber,
-    seller_uuid,
-    seller_membername: credentialSubject.seller.contactPoint.split("@").shift(),
-    seller_organization: credentialSubject.seller.name,
-    seller_archived: 0,
-    seller_last_action: new Date(),
-    buyer_uuid,
-    buyer_membername: credentialSubject.buyer.contactPoint.split("@").shift(),
-    buyer_organization: credentialSubject.buyer.name,
-    buyer_archived: 0,
-    buyer_last_action: new Date("0000-00-00 00:00:00"),
-    created_from: null,
-    root_document: null,
-    created_on: new Date(credentialSubject.invoiceDate),
-    removed_on: null,
-    opened: 0,
-    subject_line: credentialSubject.customerReferenceNumber,
-    due_by: new Date(credentialSubject.purchaseDate),
-    amount_due: `${totalPaymentDue.price} ${totalPaymentDue.priceCurrency}`,
-    document_folder: "sent",
-  };
+    const status = {
+        document_uuid,
+        document_type: 'invoice',
+        document_number: credentialSubject.invoiceNumber,
+        seller_uuid,
+        seller_membername: credentialSubject.seller.contactPoint
+            .split('@')
+            .shift(),
+        seller_organization: credentialSubject.seller.name,
+        seller_archived: 0,
+        seller_last_action: new Date(),
+        buyer_uuid,
+        buyer_membername: credentialSubject.buyer.contactPoint
+            .split('@')
+            .shift(),
+        buyer_organization: credentialSubject.buyer.name,
+        buyer_archived: 0,
+        buyer_last_action: new Date('0000-00-00 00:00:00'),
+        created_from: null,
+        root_document: null,
+        created_on: new Date(credentialSubject.invoiceDate),
+        removed_on: null,
+        opened: 0,
+        subject_line: credentialSubject.customerReferenceNumber,
+        due_by: new Date(credentialSubject.purchaseDate),
+        amount_due: `${totalPaymentDue.price} ${totalPaymentDue.priceCurrency}`,
+        document_folder: 'sent',
+    }
 
-  //console.log(document);
-  let errno, code;
+    //console.log(document);
+    let errno, code
 
-  // 1.
+    // 1.
 
-  //console.log("/buyerToSend:"+CONTACTS+":"+ seller_uuid+":"+ buyer_uuid);
+    //console.log("/buyerToSend:"+CONTACTS+":"+ seller_uuid+":"+ buyer_uuid);
 
-  // 2.
-  // Second we check to see if there is any contact information
-  const [_2, err2] = await sub.getSellerHost(CONTACTS, seller_uuid, buyer_uuid);
+    // 2.
+    // Second we check to see if there is any contact information
+    const [_2, err2] = await sub.getSellerHost(
+        CONTACTS,
+        seller_uuid,
+        buyer_uuid
+    )
 
-  if (err2) {
-    console.log("/buyerToSend:err 2");
-    return res.status(400).json(err2);
-  }
+    if (err2) {
+        console.log('/buyerToSend:err 2')
+        return res.status(400).json(err2)
+    }
 
-  // 3.
-  // Then we check to see if there is any data already registered
-  //
-  const [_3, err3] = await sub.checkForExistingDocument(
-    BUYER__DOCUMENT,
-    document_uuid
-  );
+    // 3.
+    // Then we check to see if there is any data already registered
+    //
+    const [_3, err3] = await sub.checkForExistingDocument(
+        BUYER__DOCUMENT,
+        document_uuid
+    )
 
-  if (err3) {
-    console.log("/buyerToSend:err 3");
-    return res.status(400).json(err3);
-  }
+    if (err3) {
+        console.log('/buyerToSend:err 3')
+        return res.status(400).json(err3)
+    }
 
-  /*
-   * Convert time format from ISO format to Date format.
-   */
-  // 4.
-  //
-  status.due_by = new Date(Date.parse(status.due_by));
+    /*
+     * Convert time format from ISO format to Date format.
+     */
+    // 4.
+    //
+    status.due_by = new Date(Date.parse(status.due_by))
 
-  // 5.
-  // begin Transaction
-  //
-  const [conn, _5] = await tran.connection();
-  await tran.beginTransaction(conn);
+    // 5.
+    // begin Transaction
+    //
+    const [conn, _5] = await tran.connection()
+    await tran.beginTransaction(conn)
 
-  // 6.
-  const [_6, err6] = await tran.insertDocument(
-    conn,
-    BUYER__DOCUMENT,
-    status,
-    document_json
-  );
+    // 6.
+    const [_6, err6] = await tran.insertDocument(
+        conn,
+        BUYER__DOCUMENT,
+        status,
+        document_json
+    )
 
-  if (err6) {
-    console.log("/buyerToSend:err 6");
-    errno = 6;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err6, errno));
-  }
+    if (err6) {
+        console.log('/buyerToSend:err 6')
+        errno = 6
+        code = 400
+        return res
+            .status(400)
+            .json(tran.rollbackAndReturn(conn, code, err6, errno))
+    }
 
-  // 7.
-  //
-  const [_7, err7] = await tran.insertStatus(conn, BUYER__STATUS, status);
+    // 7.
+    //
+    const [_7, err7] = await tran.insertStatus(conn, BUYER__STATUS, status)
 
-  if (err7) {
-    console.log("/buyerToSend:err 7");
-    errno = 7;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err7, errno));
-  }
+    if (err7) {
+        console.log('/buyerToSend:err 7')
+        errno = 7
+        code = 400
+        return res
+            .status(400)
+            .json(tran.rollbackAndReturn(conn, code, err7, errno))
+    }
 
-  // 8.
-  // commit
-  //
-  const [_8, err8] = await tran.commit(conn);
+    // 8.
+    // commit
+    //
+    const [_8, err8] = await tran.commit(conn)
 
-  if (err8) {
-    console.log("/buyerToSend:err 8");
-    errno = 8;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err8, errno));
-  }
+    if (err8) {
+        console.log('/buyerToSend:err 8')
+        errno = 8
+        code = 400
+        return res
+            .status(400)
+            .json(tran.rollbackAndReturn(conn, code, err8, errno))
+    }
 
-  // 9.
-  //
-  conn.end();
-  res.status(200).end("accepted");
+    // 9.
+    //
+    conn.end()
+    res.status(200).end('accepted')
 
-  console.log("/buyerToSend accepted");
-};
+    console.log('/buyerToSend accepted')
+}
 
 module.exports = {
-  handleIncomingInvoice,
-};
+    handleIncomingInvoice,
+}

--- a/modules/presentations_out.js
+++ b/modules/presentations_out.js
@@ -226,6 +226,8 @@ const makePresentation = async(url, keyPair, vc) => {
 
 	// 1 Init Presentation
 
+	console.log(url);
+
 	const [ available, _err1 ] = await initPresentation(url);
 	if(_err1) {
 		return [ null, 'could not init' ];

--- a/modules/presentations_out.js
+++ b/modules/presentations_out.js
@@ -18,54 +18,50 @@
 
 **/
 
-"use strict";
+'use strict'
 
 // NPM Libraries
 
-const axios = require('axios');
-const transmute = require('@transmute/vc.js');
+const axios = require('axios')
+const transmute = require('@transmute/vc.js')
 
 const {
-	Ed25519Signature2018,
-	Ed25519VerificationKey2018,
-} = require('@transmute/ed25519-signature-2018');
+    Ed25519Signature2018,
+    Ed25519VerificationKey2018,
+} = require('@transmute/ed25519-signature-2018')
 
 const context = {
-	"https://www.w3.org/2018/credentials/v1" : require('../context/credentials_v1.json'),
-	"https://w3id.org/traceability/v1" : require('../context/traceability_v1.json')
+    'https://www.w3.org/2018/credentials/v1': require('../context/credentials_v1.json'),
+    'https://w3id.org/traceability/v1': require('../context/traceability_v1.json'),
 }
 
-const { resolve } = require('@transmute/did-key.js');
+const { resolve } = require('@transmute/did-key.js')
 
 // Local Libraries
 
-const db = require('../database.js');
+const db = require('../database.js')
 
 /**
  * Helper Functions
  **/
 
 const checkStatus = () => {
-
-	return true;
-
+    return true
 }
 
 const documentLoader = async (iri) => {
+    if (context[iri]) {
+        return { document: context[iri] }
+    }
 
-	if(context[iri]) {
-		return { document: context[iri] };
-	}
+    if (iri.indexOf('did:key') === 0) {
+        const document = await resolve(iri)
+        return { document }
+    }
 
-	if(iri.indexOf('did:key') === 0) {
-		const document = await resolve(iri);
-		return { document };
-	}
-
-	const message = `Unsupported iri: ${iri}`;
-	console.error(message);
-	throw new Error(message);
-
+    const message = `Unsupported iri: ${iri}`
+    console.error(message)
+    throw new Error(message)
 }
 
 /**
@@ -73,187 +69,178 @@ const documentLoader = async (iri) => {
  **/
 
 const getPrivateKeys = async (member_did) => {
-
-	const sql = `
+    const sql = `
 		SELECT
 			public_key
 		FROM
 			privatekeys
 		WHERE
 			member_did = ?
-	`;
+	`
 
-	const args = [
-		member_did
-	];
+    const args = [member_did]
 
-	let row;
-	try {
-		row = await db.selectOne(sql, args);
-	} catch(err) {
-		return [ null, err ];
-	}
+    let row
+    try {
+        row = await db.selectOne(sql, args)
+    } catch (err) {
+        return [null, err]
+    }
 
-	const keyPair = JSON.parse(row.public_key);
-	return [ keyPair, null ];
-
+    const keyPair = JSON.parse(row.public_key)
+    return [keyPair, null]
 }
 
 const initPresentation = async (url) => {
+    const method = 'post'
 
-	const method = 'post';
+    const data = {
+        query: [
+            {
+                type: 'QueryByExample',
+                credentialQuery: [
+                    {
+                        type: ['VerifiableCredential'],
+                        reason: 'We want to present credentials.',
+                    },
+                ],
+            },
+        ],
+    }
 
-	const data = {
-		query: [
-			{
-				type: "QueryByExample",
-				credentialQuery: [
-					{
-						type: ["VerifiableCredential"],
-						reason: "We want to present credentials."
-					}
-				]
-			}
-		]
-	};
+    const params = { method, url, data }
 
-	const params = { method, url, data };
+    let response
+    try {
+        response = await axios(params)
+    } catch (err) {
+        const error = {
+            status: -1,
+            data: 'unknown error',
+        }
 
-	let response;
-	try {
-		response = await axios(params);
-	} catch(err) {
-		const error = {
-			status: -1,
-			data: 'unknown error'
-		}
+        if (err.response) {
+            error.status = err.response.status
+            error.data = err.response.data
+        } else if (err.code === 'ECONNRESET') {
+            error.status = 500
+            error.data = 'ECONNRESET'
+        } else {
+            error.status = 400
+            error.data = 'Undefined Error'
+        }
 
-		if(err.response) {
-			error.status = err.response.status;
-			error.data = err.response.data;
-		} else if(err.code === 'ECONNRESET') {
-			error.status = 500;
-			error.data = 'ECONNRESET';
-		} else {
-			error.status = 400;
-			error.data = 'Undefined Error';
-		}
+        return [null, error]
+    }
 
-		return [ null, error ];
-	}
-
-	return [ response.data, null ];
-
+    return [response.data, null]
 }
 
-const sendPresentation = async( url, keyPair, domain, challenge, vc ) => {
+const sendPresentation = async (url, keyPair, domain, challenge, vc) => {
+    const presentation = {
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        id: `urn:uuid:${challenge}`,
+        type: ['VerifiablePresentation'],
+        verifiableCredential: [vc],
+        holder: keyPair.controller,
+    }
 
-	const presentation = {
-		'@context': [
-			'https://www.w3.org/2018/credentials/v1'
-		],
-		id: `urn:uuid:${challenge}`,
-		type: [
-			'VerifiablePresentation'
-		],
-		verifiableCredential: [ vc ],
-		holder: keyPair.controller,
-	};
+    url = url.replace('available', 'submissions')
+    const method = 'post'
 
-	url = url.replace('available', 'submissions');
-	const method = 'post';
+    const data = await signPresentation(
+        presentation,
+        keyPair,
+        domain,
+        challenge
+    )
 
-	const data = await signPresentation(
-		presentation,
-		keyPair,
-		domain,
-		challenge);
+    const params = { method, url, data }
 
-	const params = { method, url, data };
+    let response
+    try {
+        response = await axios(params)
+    } catch (err) {
+        const error = {
+            status: -1,
+            data: 'unknown error',
+        }
 
-	let response;
-	try {
-		response = await axios(params);
-	} catch(err) {
-		const error = {
-			status: -1,
-			data: 'unknown error'
-		}
+        if (err.response) {
+            error.status = err.response.status
+            error.data = err.response.data
+        } else if (err.code === 'ECONNRESET') {
+            error.status = 500
+            error.data = 'ECONNRESET'
+        } else {
+            error.status = 400
+            error.data = 'Undefined Error'
+        }
 
-		if(err.response) {
-			error.status = err.response.status;
-			error.data = err.response.data;
-		} else if(err.code === 'ECONNRESET') {
-			error.status = 500;
-			error.data = 'ECONNRESET';
-		} else {
-			error.status = 400;
-			error.data = 'Undefined Error';
-		}
+        return [null, error]
+    }
 
-		return [ null, error ];
-	}
-
-	return [ response.data, null ];
-
+    return [response.data, null]
 }
 
-const signPresentation  = async (presentation, keyPair, domain, challenge) => {
+const signPresentation = async (presentation, keyPair, domain, challenge) => {
+    console.log('okay?')
 
-	console.log('okay?');
+    const { items } = await transmute.verifiable.presentation.create({
+        presentation,
+        format: ['vp'],
+        domain,
+        challenge,
+        documentLoader,
+        suite: new Ed25519Signature2018({
+            key: await Ed25519VerificationKey2018.from(keyPair),
+        }),
+    })
 
-	const { items } = await transmute.verifiable.presentation.create({
-		presentation,
-		format: ['vp'],
-		domain,
-		challenge,
-		documentLoader,
-		suite: new Ed25519Signature2018({
-			key: await Ed25519VerificationKey2018.from(keyPair)
-		})
-	});
+    console.log('oh god!!')
 
-	console.log('oh god!!');
-
-	const [ signedPresentation ] = items;
-	return signedPresentation;
-
+    const [signedPresentation] = items
+    return signedPresentation
 }
 
-const makePresentation = async(url, keyPair, vc) => {
+const makePresentation = async (url, keyPair, vc) => {
+    console.log('making the presentation!!!')
 
-	console.log('making the presentation!!!');
+    // 1 Init Presentation
 
-	// 1 Init Presentation
+    console.log(url)
 
-	console.log(url);
+    const [available, _err1] = await initPresentation(url)
+    if (_err1) {
+        return [null, 'could not init']
+    }
 
-	const [ available, _err1 ] = await initPresentation(url);
-	if(_err1) {
-		return [ null, 'could not init' ];
-	}
+    const { domain, challenge } = available
+    console.log(domain, challenge)
 
-	const { domain, challenge } = available;
-	console.log( domain, challenge );
+    // 2 Send Presentation
 
-	// 2 Send Presentation
-	
-	const [ send, _err2 ] = await sendPresentation(url, keyPair, domain, challenge, vc);
-	if(_err2) {
-		console.log(_err2);
-		return [ null, 'could not submit' ];
-	}
+    const [send, _err2] = await sendPresentation(
+        url,
+        keyPair,
+        domain,
+        challenge,
+        vc
+    )
+    if (_err2) {
+        console.log(_err2)
+        return [null, 'could not submit']
+    }
 
-	// Return Success
+    // Return Success
 
-	return [ send, null ];
-
+    return [send, null]
 }
 
 module.exports = {
-	getPrivateKeys : getPrivateKeys,
-	initPresentation : initPresentation,
-	sendPresentation : sendPresentation,
-	signPresentation : signPresentation,
-	makePresentation : makePresentation,
+    getPrivateKeys: getPrivateKeys,
+    initPresentation: initPresentation,
+    sendPresentation: sendPresentation,
+    signPresentation: signPresentation,
+    makePresentation: makePresentation,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,6 +4549,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
       "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "4.3.0"
       }
@@ -4581,6 +4582,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -4651,6 +4653,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -4660,6 +4663,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
       "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
+      "hasInstallScript": true,
       "dependencies": {
         "abstract-leveldown": "^7.2.0",
         "napi-macros": "~2.0.0",
@@ -4731,6 +4735,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -4741,6 +4746,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/routes/presentations.js
+++ b/routes/presentations.js
@@ -22,104 +22,105 @@
 
 // Import Router
 
-const express					= require('express');
-const router					= express.Router();
-module.exports					= router;
+const express = require("express");
+const router = express.Router();
+module.exports = router;
 
 // Import Libraries
 
-const uuidv4					= require('uuid').v4;
-const { verifyPresentation } = require('./sign_your_credentials.js');
-const { handleContactRequest } = require('../modules/contacts_in.js');
+const uuidv4 = require("uuid").v4;
+const { verifyPresentation } = require("./sign_your_credentials.js");
+const { handleContactRequest } = require("../modules/contacts_in.js");
+const { handleIncomingInvoice } = require("../modules/invoices_in.js");
 
 // Global Variable for Storing Challenges
 
-const challenges = {}
+const challenges = {};
 
-// Define 
+// Define
 
-router.post('/available', async (req, res) => {
+router.post("/available", async (req, res) => {
+  console.log("--- /api/presentations/available ---");
+  console.log(req.body);
 
-	console.log('--- /api/presentations/available ---');
-	console.log(req.body);
+  // Create a challenge
+  const domain = process.env.DOMAIN;
+  const challenge = uuidv4();
 
-	// Create a challenge
-	const domain = process.env.DOMAIN;
-	const challenge = uuidv4();
+  // Store it in Redis with a expiration timer of 10 seconds
+  challenges[challenge] = 1;
+  setTimeout(() => {
+    delete challenges[challenge];
+  }, 10 * 1000);
 
-	// Store it in Redis with a expiration timer of 10 seconds
-	challenges[challenge] = 1;
-	setTimeout( () => {
-		delete challenges[challenge];
-	}, 10 * 1000);
-
-	// Return the domain and challenge
-	res.json({
-		...req.body,
-		domain,
-		challenge
-	});
-
+  // Return the domain and challenge
+  res.json({
+    ...req.body,
+    domain,
+    challenge,
+  });
 });
 
-router.post('/submissions', async (req, res) => {
+router.post("/submissions", async (req, res) => {
+  console.log("--- /api/presentations/submissions ---");
+  const signedPresentation = req.body;
+  const { domain, challenge } = signedPresentation.proof;
 
-	console.log('--- /api/presentations/submissions ---');
-	const signedPresentation = req.body;
-	const { domain, challenge } = signedPresentation.proof;
+  // 1.
+  // First we need to see if the challenge is still available
+  // And delete it if it exists
 
-	// 1.
-	// First we need to see if the challenge is still available
-	// And delete it if it exists
+  if (!challenges[challenge]) {
+    // return 400;
+  }
+  delete challenges[challenge];
 
-	if(!challenges[challenge]) {
-		// return 400;
-	}
-	delete challenges[challenge];
+  // 2.
+  // Then we need to verify the presentation
+  // TODO: Figure out why this does not verify
+  // https://github.com/WebServiceDevelopment/PrivateInvoice/issues/15
 
-	// 2.
-	// Then we need to verify the presentation 
-	// TODO: Figure out why this does not verify
-	// https://github.com/WebServiceDevelopment/PrivateInvoice/issues/15
+  const result = await verifyPresentation(signedPresentation);
 
-	const result = await verifyPresentation(signedPresentation);
+  console.log(result);
+  console.log(result.credentials);
+  console.log(result.presentation);
 
-	console.log(result);
-	console.log(result.credentials);
-	console.log(result.presentation);
+  if (!result.verified) {
+    // return 400;
+  }
 
-	if(!result.verified) {
-		// return 400;
-	}
+  // 3.
+  // Assuming that works, then we need to figure out how to
+  // handle the contents of credentials that have been sent
+  // to us
 
-	// 3.
-	// Assuming that works, then we need to figure out how to
-	// handle the contents of credentials that have been sent
-	// to us
+  console.log("Signed Presentation");
+  console.log(signedPresentation);
 
-	console.log('Signed Presentation');
-	console.log(signedPresentation);
+  const { verifiableCredential } = signedPresentation;
 
-	const { verifiableCredential } = signedPresentation;
+  console.log("Verifiable Credential List");
+  console.log(verifiableCredential);
 
-	console.log('Verifiable Credential List');
-	console.log( verifiableCredential);
+  const [credential] = verifiableCredential;
 
-	const [ credential ] = verifiableCredential;
+  console.log("Credential");
+  console.log(credential);
 
-	console.log('Credential');
-	console.log(credential);
+  // First option is a contact request, which does not require the
+  // controller to be in the list of contacts
 
-	// First option is a contact request, which does not require the
-	// controller to be in the list of contacts
+  if (credential.type.indexOf("VerifiableBusinessCard") !== -1) {
+    // Handle Contact Request
+    const [status, message] = await handleContactRequest(credential);
+    return res.status(status).end(message);
+  } else if (credential.type.indexOf("CommercialInvoiceCertificate") !== -1) {
+    // Handle Commercial Invoice
+    console.log("handle commercial invoice!!!!");
+    return await handleIncomingInvoice(credential, res);
+    // return res.status(400).end("Stahhp it");
+  }
 
-	if(credential.type.indexOf('VerifiableBusinessCard') !== -1) {
-		// Handle Contact Request
-		const [ status, message ] = await handleContactRequest( credential );
-		return res.status(status).end(message);
-	}
-
-	res.status(400).end('no valid credential detected');
-
-
+  res.status(400).end("no valid credential detected");
 });

--- a/routes/presentations.js
+++ b/routes/presentations.js
@@ -18,109 +18,109 @@
     
 **/
 
-"use strict";
+'use strict'
 
 // Import Router
 
-const express = require("express");
-const router = express.Router();
-module.exports = router;
+const express = require('express')
+const router = express.Router()
+module.exports = router
 
 // Import Libraries
 
-const uuidv4 = require("uuid").v4;
-const { verifyPresentation } = require("./sign_your_credentials.js");
-const { handleContactRequest } = require("../modules/contacts_in.js");
-const { handleIncomingInvoice } = require("../modules/invoices_in.js");
+const uuidv4 = require('uuid').v4
+const { verifyPresentation } = require('./sign_your_credentials.js')
+const { handleContactRequest } = require('../modules/contacts_in.js')
+const { handleIncomingInvoice } = require('../modules/invoices_in.js')
 
 // Global Variable for Storing Challenges
 
-const challenges = {};
+const challenges = {}
 
 // Define
 
-router.post("/available", async (req, res) => {
-  console.log("--- /api/presentations/available ---");
-  console.log(req.body);
+router.post('/available', async (req, res) => {
+    console.log('--- /api/presentations/available ---')
+    console.log(req.body)
 
-  // Create a challenge
-  const domain = process.env.DOMAIN;
-  const challenge = uuidv4();
+    // Create a challenge
+    const domain = process.env.DOMAIN
+    const challenge = uuidv4()
 
-  // Store it in Redis with a expiration timer of 10 seconds
-  challenges[challenge] = 1;
-  setTimeout(() => {
-    delete challenges[challenge];
-  }, 10 * 1000);
+    // Store it in Redis with a expiration timer of 10 seconds
+    challenges[challenge] = 1
+    setTimeout(() => {
+        delete challenges[challenge]
+    }, 10 * 1000)
 
-  // Return the domain and challenge
-  res.json({
-    ...req.body,
-    domain,
-    challenge,
-  });
-});
+    // Return the domain and challenge
+    res.json({
+        ...req.body,
+        domain,
+        challenge,
+    })
+})
 
-router.post("/submissions", async (req, res) => {
-  console.log("--- /api/presentations/submissions ---");
-  const signedPresentation = req.body;
-  const { domain, challenge } = signedPresentation.proof;
+router.post('/submissions', async (req, res) => {
+    console.log('--- /api/presentations/submissions ---')
+    const signedPresentation = req.body
+    const { domain, challenge } = signedPresentation.proof
 
-  // 1.
-  // First we need to see if the challenge is still available
-  // And delete it if it exists
+    // 1.
+    // First we need to see if the challenge is still available
+    // And delete it if it exists
 
-  if (!challenges[challenge]) {
-    // return 400;
-  }
-  delete challenges[challenge];
+    if (!challenges[challenge]) {
+        // return 400;
+    }
+    delete challenges[challenge]
 
-  // 2.
-  // Then we need to verify the presentation
-  // TODO: Figure out why this does not verify
-  // https://github.com/WebServiceDevelopment/PrivateInvoice/issues/15
+    // 2.
+    // Then we need to verify the presentation
+    // TODO: Figure out why this does not verify
+    // https://github.com/WebServiceDevelopment/PrivateInvoice/issues/15
 
-  const result = await verifyPresentation(signedPresentation);
+    const result = await verifyPresentation(signedPresentation)
 
-  console.log(result);
-  console.log(result.credentials);
-  console.log(result.presentation);
+    console.log(result)
+    console.log(result.credentials)
+    console.log(result.presentation)
 
-  if (!result.verified) {
-    // return 400;
-  }
+    if (!result.verified) {
+        // return 400;
+    }
 
-  // 3.
-  // Assuming that works, then we need to figure out how to
-  // handle the contents of credentials that have been sent
-  // to us
+    // 3.
+    // Assuming that works, then we need to figure out how to
+    // handle the contents of credentials that have been sent
+    // to us
 
-  console.log("Signed Presentation");
-  console.log(signedPresentation);
+    console.log('Signed Presentation')
+    console.log(signedPresentation)
 
-  const { verifiableCredential } = signedPresentation;
+    const { verifiableCredential } = signedPresentation
 
-  console.log("Verifiable Credential List");
-  console.log(verifiableCredential);
+    console.log('Verifiable Credential List')
+    console.log(verifiableCredential)
 
-  const [credential] = verifiableCredential;
+    const [credential] = verifiableCredential
 
-  console.log("Credential");
-  console.log(credential);
+    console.log('Credential')
+    console.log(credential)
 
-  // First option is a contact request, which does not require the
-  // controller to be in the list of contacts
+    // First option is a contact request, which does not require the
+    // controller to be in the list of contacts
 
-  if (credential.type.indexOf("VerifiableBusinessCard") !== -1) {
-    // Handle Contact Request
-    const [status, message] = await handleContactRequest(credential);
-    return res.status(status).end(message);
-  } else if (credential.type.indexOf("CommercialInvoiceCertificate") !== -1) {
-    // Handle Commercial Invoice
-    console.log("handle commercial invoice!!!!");
-    return await handleIncomingInvoice(credential, res);
-    // return res.status(400).end("Stahhp it");
-  }
+    if (credential.type.indexOf('VerifiableBusinessCard') !== -1) {
+        // Handle Contact Request
+        const [status, message] = await handleContactRequest(credential)
+        return res.status(status).end(message)
+    } else if (credential.type.indexOf('CommercialInvoiceCertificate') !== -1) {
+        // Handle Commercial Invoice
+        console.log('handle commercial invoice!!!!')
+        return await handleIncomingInvoice(credential, res)
+        // return res.status(400).end("Stahhp it");
+    }
 
-  res.status(400).end("no valid credential detected");
-});
+    res.status(400).end('no valid credential detected')
+})

--- a/routes/seller_invoice.js
+++ b/routes/seller_invoice.js
@@ -57,7 +57,7 @@ const SELLER_ARCHIVE_STATUS = "seller_status_archive";
 const CONTACTS = "contacts";
 
 const getPrivateKeys = async (member_did) => {
-  const sql = `
+	const sql = `
 		SELECT
 			public_key
 		FROM
@@ -66,17 +66,17 @@ const getPrivateKeys = async (member_did) => {
 			member_did = ?
 	`;
 
-  const args = [member_did];
+	const args = [member_did];
 
-  let row;
-  try {
-    row = await db.selectOne(sql, args);
-  } catch (err) {
-    return [null, err];
-  }
+	let row;
+	try {
+		row = await db.selectOne(sql, args);
+	} catch (err) {
+		return [null, err];
+	}
 
-  const keyPair = JSON.parse(row.public_key);
-  return [keyPair, null];
+	const keyPair = JSON.parse(row.public_key);
+	return [keyPair, null];
 };
 
 // ------------------------------- End Points -------------------------------
@@ -87,682 +87,712 @@ const getPrivateKeys = async (member_did) => {
  */
 
 router.post("/send", async function (req, res) {
-  const start = Date.now();
+	const start = Date.now();
 
-  const { document_uuid } = req.body;
-  const { member_uuid } = req.session.data;
+	const { document_uuid } = req.body;
+	const { member_uuid } = req.session.data;
 
-  let code, errno;
+	let code, errno;
+	const USE_PRESENTATION = false;
 
-  // 1.
-  const [buyer_uuid, err1] = await sub.getBuyerUuidForDraft(
-    SELLER_DRAFT_STATUS,
-    document_uuid,
-    member_uuid
-  );
-  if (err1) {
-    console.log(
-      "Error 1.1 status = 400 err=" +
-        err1 +
-        ":" +
-        document_uuid +
-        ":" +
-        member_uuid
-    );
+	// 1.
+	const [buyer_uuid, err1] = await sub.getBuyerUuidForDraft(
+		SELLER_DRAFT_STATUS,
+		document_uuid,
+		member_uuid
+	);
+	if (err1) {
+		console.log(
+			"Error 1.1 status = 400 err=" +
+				err1 +
+				":" +
+				document_uuid +
+				":" +
+				member_uuid
+		);
 
-    return res.status(400).json(err1);
-  }
-  if (buyer_uuid == null) {
-    console.log("Error 1.2 :" + document_uuid + ":" + member_uuid);
-    return res.status(400).json({ err: 1, msg: "buyer_uuid is not found" });
-  }
+		return res.status(400).json(err1);
+	}
+	if (buyer_uuid == null) {
+		console.log("Error 1.2 :" + document_uuid + ":" + member_uuid);
+		return res.status(400).json({ err: 1, msg: "buyer_uuid is not found" });
+	}
 
-  // 2.
-  const [buyer_host, err2] = await sub.getBuyerHost(
-    CONTACTS,
-    member_uuid,
-    buyer_uuid
-  );
-  if (err2) {
-    console.log(
-      "Error 2 status = 400 err=" + err2 + ":" + member_uuid + ":" + buyer_uuid
-    );
-    return res.status(400).json(err2);
-  }
+	// 2.
+	const [buyer_host, err2] = await sub.getBuyerHost(
+		CONTACTS,
+		member_uuid,
+		buyer_uuid
+	);
+	if (err2) {
+		console.log(
+			"Error 2 status = 400 err=" + err2 + ":" + member_uuid + ":" + buyer_uuid
+		);
+		return res.status(400).json(err2);
+	}
 
-  // 4.
-  // DRAFT_STATUS
-  // First we go ahead and get the draft status.
-  //
-  const [status, _4] = await sub.getStatus(SELLER_DRAFT_STATUS, document_uuid);
+	if(!USE_PRESENTATION) {
+		//3. buyer connect check
+		const [ code3 , err3 ] = await to_buyer.connect(buyer_host, member_uuid, buyer_uuid);
 
-  if (status.document_uuid == null) {
-    console.log("document_uuid is null");
+		if(code3 !== 200) {
+			console.log("Error 3 code="+code3+":err="+err3);
+			let msg;
+			if(code == 500) {
+				msg = {"err":"buyer connect check:ECONNRESET"};
+			} else {
+				switch(err3) {
+				case "Not found.":
+					msg = {"err":"The destination node cannot be found."};
+				break;
+				default:
+					msg = {"err":err3};
+				break;
+				}
+			}
+			return res.status(400).json(msg);
+		}
+	}
 
-    res.json({ err: 4, msg: "document_uuid is null" });
-    return;
-  }
+	// 4.
+	// DRAFT_STATUS
+	// First we go ahead and get the draft status.
+	//
+	const [status, _4] = await sub.getStatus(SELLER_DRAFT_STATUS, document_uuid);
 
-  // 5.
-  // Creating Send data.
-  //
-  status.document_uuid = document_uuid;
-  status.document_type = "invoice";
-  status.document_folder = "sent";
+	if (status.document_uuid == null) {
+		console.log("document_uuid is null");
 
-  // 6.
-  // Second we go ahead and get the draft document
-  //
-  const [document] = await sub.getDraftDocumentForSend(
-    SELLER_DRAFT_DOCUMENT,
-    document_uuid
-  );
+		res.json({ err: 4, msg: "document_uuid is null" });
+		return;
+	}
 
-  if (document.document_uuid == null) {
-    console.log("document_uuid is null");
+	// 5.
+	// Creating Send data.
+	//
+	status.document_uuid = document_uuid;
+	status.document_type = "invoice";
+	status.document_folder = "sent";
 
-    res.json({ err: 6, msg: "document_uuid is null" });
-    return;
-  }
+	// 6.
+	// Second we go ahead and get the draft document
+	//
+	const [document] = await sub.getDraftDocumentForSend(
+		SELLER_DRAFT_DOCUMENT,
+		document_uuid
+	);
 
-  document.seller_uuid = member_uuid;
-  document.buyer_uuid = buyer_uuid;
+	if (document.document_uuid == null) {
+		console.log("document_uuid is null");
 
-  // 7.
-  // signInvoice
-  //
+		res.json({ err: 6, msg: "document_uuid is null" });
+		return;
+	}
 
-  const signedCredential = await sign_your_credentials.signInvoice(
-    document.document_uuid,
-    document.document_json
-  );
-  const document_json = JSON.stringify(signedCredential);
+	document.seller_uuid = member_uuid;
+	document.buyer_uuid = buyer_uuid;
 
-  document.document_json = document_json;
+	// 7.
+	// signInvoice
+	//
 
-  if (document.document_json == null) {
-    console.log("document_json == null");
+	const signedCredential = await sign_your_credentials.signInvoice(
+		document.document_uuid,
+		document.document_json
+	);
+	const document_json = JSON.stringify(signedCredential);
 
-    res.json({ err: 7, msg: "document_json is null" });
-    return;
-  }
+	document.document_json = document_json;
 
-  // 8.
-  // Does document_uuid already notexist in the status table?
-  //
-  const [_8, err8] = await sub.notexist_check(SELLER_STATUS, document_uuid);
-  if (err8) {
-    errno = 8;
-    console.log("Error: " + errno);
-    return res.status(400).json({ err: errno, msg: err8 });
-  }
+	if (document.document_json == null) {
+		console.log("document_json == null");
 
-  // 9.
-  // Does document_uuid already notexist in the document table?
-  //
-  const [_9, err9] = await sub.notexist_check(SELLER_DOCUMENT, document_uuid);
-  if (err9) {
-    errno = 9;
-    console.log("Error: " + errno);
-    return res.status(400).json({ err: errno, msg: err9 });
-  }
+		res.json({ err: 7, msg: "document_json is null" });
+		return;
+	}
 
-  // 10.
-  // begin Transaction
-  //
-  const [conn, _10] = await tran.connection();
-  await tran.beginTransaction(conn);
+	// 8.
+	// Does document_uuid already notexist in the status table?
+	//
+	const [_8, err8] = await sub.notexist_check(SELLER_STATUS, document_uuid);
+	if (err8) {
+		errno = 8;
+		console.log("Error: " + errno);
+		return res.status(400).json({ err: errno, msg: err8 });
+	}
 
-  // 11.
-  // Then we go ahead and insert into the status
-  //
-  const [_11, err11] = await tran.insertStatus(conn, SELLER_STATUS, status);
+	// 9.
+	// Does document_uuid already notexist in the document table?
+	//
+	const [_9, err9] = await sub.notexist_check(SELLER_DOCUMENT, document_uuid);
+	if (err9) {
+		errno = 9;
+		console.log("Error: " + errno);
+		return res.status(400).json({ err: errno, msg: err9 });
+	}
 
-  if (err11) {
-    errno = 11;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err11, errno));
-  }
+	// 10.
+	// begin Transaction
+	//
+	const [conn, _10] = await tran.connection();
+	await tran.beginTransaction(conn);
 
-  // 12.
-  // And then we need to insert into database
-  //
-  const [_12, err12] = await tran.insertDocument(
-    conn,
-    SELLER_DOCUMENT,
-    status,
-    document_json
-  );
-  if (err12) {
-    errno = 12;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err12, errno));
-  }
+	// 11.
+	// Then we go ahead and insert into the status
+	//
+	const [_11, err11] = await tran.insertStatus(conn, SELLER_STATUS, status);
 
-  // 13.
-  // Remove from SELLER_DRAFT_STATUS with docunent_uuid key
-  //
-  const [_13, err13] = await tran.deleteStatus(
-    conn,
-    SELLER_DRAFT_STATUS,
-    status
-  );
-  if (err13) {
-    errno = 13;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err13, errno));
-  }
+	if (err11) {
+		errno = 11;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err11, errno));
+	}
 
-  // 14.
-  // Remove from SELLER_DRAFT_DOCUMENT with docunent_uuid key
-  //
-  const [_14, err14] = await tran.deleteDocument(
-    conn,
-    SELLER_DRAFT_DOCUMENT,
-    status
-  );
-  if (err14) {
-    errno = 14;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err14, errno));
-  }
+	// 12.
+	// And then we need to insert into database
+	//
+	const [_12, err12] = await tran.insertDocument(
+		conn,
+		SELLER_DOCUMENT,
+		status,
+		document_json
+	);
+	if (err12) {
+		errno = 12;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err12, errno));
+	}
 
-  // 15.
-  // Send 'send' message to buyer.
+	// 13.
+	// Remove from SELLER_DRAFT_STATUS with docunent_uuid key
+	//
+	const [_13, err13] = await tran.deleteStatus(
+		conn,
+		SELLER_DRAFT_STATUS,
+		status
+	);
+	if (err13) {
+		errno = 13;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err13, errno));
+	}
 
-  const presenationSlug = "/api/presentations/available";
-  const url = buyer_host + presenationSlug;
+	// 14.
+	// Remove from SELLER_DRAFT_DOCUMENT with docunent_uuid key
+	//
+	const [_14, err14] = await tran.deleteDocument(
+		conn,
+		SELLER_DRAFT_DOCUMENT,
+		status
+	);
+	if (err14) {
+		errno = 14;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err14, errno));
+	}
 
-  const [keyPair] = await getPrivateKeys(member_uuid);
-  const vc = JSON.parse(document.document_json);
-  const [code15, err15] = await makePresentation(url, keyPair, vc);
+	// 15.
+	// Send 'send' message to buyer.
+	
+	if(!USE_PRESENTATION) {
+		const [ code15, err15 ] = await to_buyer.sendInvoice(buyer_host, document, status);
+		if(parseInt(code15) !== 200) {
+			errno = 15;
+			return res.status(400).json(tran.rollbackAndReturn(conn, code15, err15, errno));
+		}
 
-  if (err15) {
-    console.log("OMG nuuuu it failed");
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code15, 15, errno));
-  }
+	} else {
+		const presenationSlug = "/api/presentations/available";
+		const url = buyer_host + presenationSlug;
 
-  // 16.
-  // commit
-  //
-  const [_16, err16] = await tran.commit(conn);
+		const [keyPair] = await getPrivateKeys(member_uuid);
+		const vc = JSON.parse(document.document_json);
+		const [ code15, err15 ] = await makePresentation(url, keyPair, vc);
+		
+		if (err15) {
+			return res.status(400).json(tran.rollbackAndReturn(conn, code15, 15, errno));
+		}
+	}
 
-  if (err16) {
-    errno = 16;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err16, errno));
-  }
+	// 16.
+	// commit
+	//
+	const [_16, err16] = await tran.commit(conn);
 
-  // 17.
-  //
-  conn.end();
+	if (err16) {
+		errno = 16;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err16, errno));
+	}
 
-  //console.log("/send accepted");
+	// 17.
+	//
+	conn.end();
 
-  res.json({
-    err: 0,
-    msg: status.document_uuid,
-  });
+	//console.log("/send accepted");
 
-  const end = Date.now();
-  console.log("/send Time: %d ms", end - start);
+	res.json({
+		err: 0,
+		msg: status.document_uuid,
+	});
+
+	const end = Date.now();
+	console.log("/send Time: %d ms", end - start);
 });
 
 /*
  * [ Move to Draft ]
  */
 router.post("/recreate", async function (req, res) {
-  const METHOD = "/recreate";
-
-  let start = Date.now();
-
-  const { document_uuid } = req.body;
-  const { member_uuid } = req.session.data;
-
-  let errno, code;
-
-  let status, document;
-
-  // 1.
-  //
-  const [buyer_uuid, err1] = await sub.getBuyerUuid(
-    SELLER_STATUS,
-    document_uuid,
-    member_uuid
-  );
-  if (err1) {
-    console.log("Error 1.1 status = 400 err=" + err1);
-
-    return res.status(400).json(err1);
-  }
-
-  // 2.
-  //
-  const [buyer_host, err2] = await sub.getBuyerHost(
-    CONTACTS,
-    member_uuid,
-    buyer_uuid
-  );
-  if (err2) {
-    console.log("Error 1.2 status = 400 err=" + err2);
-    return res.status(400).json(err2);
-  }
-
-  //3. buyer connect check
-  //
-  const [code3, err3] = await to_buyer.connect(
-    buyer_host,
-    member_uuid,
-    buyer_uuid
-  );
-
-  if (code3 !== 200) {
-    console.log("Error 3.1 status = 400 code=" + code3);
-    let msg;
-    if (code == 500) {
-      msg = { err: "buyer connect check:ECONNRESET" };
-    } else {
-      switch (err3) {
-        case "Not found.":
-          msg = { err: "The destination node cannot be found." };
-          break;
-        default:
-          msg = { err: err3 };
-          break;
-      }
-    }
-    return res.status(400).json(msg);
-  }
-
-  // 4
-  // STATUS
-  // First we go ahead and get the status.
-  //
-  const [old_status, _4] = await sub.getStatus(SELLER_STATUS, document_uuid);
-
-  if (old_status.document_uuid == null) {
-    console.log("document_uuid is null");
-
-    res.json({
-      err: 32,
-      msg: "document_uuid is null",
-    });
-    return;
-  }
-
-  // 5.
-  // Creating Draft data.
-  //
-  let prefix = "inv-";
-
-  status = JSON.parse(JSON.stringify(old_status));
-  status.document_uuid = uuidv1();
-  status.document_type = "invoice";
-  status.document_folder = "draft";
-
-  status.document_number = prefix + uniqid.time();
-  let d = new Date();
-  status.create_on = d.toISOString();
-  status.due_by = moment().add(30, "days").format("YYYY-MM-DD");
-
-  // 6.
-  // Second we go ahead and get the document
-  //
-  const [old_document, _6] = await sub.getDocument(
-    SELLER_DOCUMENT,
-    document_uuid
-  );
-
-  if (old_document.document_uuid == null) {
-    console.log("document_uuid is null");
-
-    res.json({
-      err: 42,
-      msg: "document_uuid is null",
-    });
-    return;
-  }
-
-  // 7.
-  // Creating Send data.
-  //
-
-  document = {};
-
-  // 7.1 document_uuid
-  //
-  document.document_uuid = status.document_uuid;
-
-  // 7.2 document_json
-  //
-  let document_json = JSON.parse(old_document.document_json);
-
-  document_json.credentialSubject.type = "Invoice";
-
-  // Update if customerReferenceNumber is revised.
-  //
-  // document_json.credentialSubject.customerReferenceNumber = document_json.credentialSubject.customerReferenceNumber;
-
-  document_json.credentialSubject.identifier = status.document_uuid;
-  document_json.credentialSubject.invoiceNumber = status.document_number;
-  document_json.credentialSubject.purchaseDate = status.due_by;
-  document_json.credentialSubject.invoiceDate = status.create_on;
-
-  document.document_json = JSON.stringify(document_json);
-
-  // 7.3 document_type
-  //
-  document.document_type = status.document_type;
-
-  // 7.4 subject_line
-  //
-  document.subject_line = old_status.subject_line;
-
-  // 7.5 currency_options
-  //
-  const currency_options = {
-    formatWithSymbol: true,
-    symbol: "Gwei",
-    separator: ",",
-    decimal: ".",
-    precision: 0,
-    pattern: "# !",
-  };
-  document.currency_options = JSON.stringify(currency_options);
-
-  // 7.6 seller_uuid
-  //
-  document.seller_uuid = old_status.seller_uuid;
-
-  // 7.7 seller_details
-  //
-  let seller = document_json.credentialSubject.seller;
-  let seller_details = {};
-  seller_details.organization_name = seller.name;
-  seller_details.organization_tax_id = seller.taxId;
-  seller_details.organization_department = seller.description;
-  seller_details.organization_building = seller.address.streetAddress;
-  seller_details.building = seller.address.addressLocality;
-  seller_details.addressCountry = seller.address.addressCountry;
-  seller_details.addressRegion = seller.address.addressRegion;
-  seller_details.addressCity = seller.address.addressCity;
-
-  document.seller_details = JSON.stringify(seller_details);
-
-  // 7.8 seller_membername
-  //
-  let seller_membername =
-    document_json.credentialSubject.seller.contactPoint.split("@")[0];
-  document.seller_membername = seller_membername;
-
-  // 7.9 buyer_uuid
-  //
-  document.buyer_uuid = old_status.buyer_uuid;
-
-  // 7.10 buyer_details
-  //
-  let buyer = document_json.credentialSubject.buyer;
-  let buyer_details = {};
-  buyer_details.organization_name = buyer.name;
-  buyer_details.organization_tax_id = buyer.taxId;
-  buyer_details.organization_department = buyer.description;
-  buyer_details.organization_building = buyer.address.streetAddress;
-  buyer_details.building = buyer.address.addressLocality;
-  buyer_details.addressCountry = buyer.addressCountry;
-  buyer_details.addressRegion = buyer.addressRegion;
-  buyer_details.addressCity = buyer.addressCity;
-
-  document.buyer_details = JSON.stringify(buyer_details);
-
-  // 7.11 buyer_membername
-  //
-  let buyer_membername =
-    document_json.credentialSubject.buyer.contactPoint.split("@")[0];
-  document.buyer_membername = buyer_membername;
-
-  // 7.12 create_on
-  //
-  document.create_on = status.create_on;
-
-  // 7.13 document_meta
-  //
-  document.document_meta = {};
-
-  let document_meta = {};
-  document_meta.document_number = status.document_number;
-  document_meta.created_on = status.create_on.substr(0, 10);
-  document_meta.taxId = document_json.credentialSubject.seller.taxId;
-  document_meta.due_by = status.due_by;
-
-  document.document_meta = JSON.stringify(document_meta);
-
-  // 7.14 document_body
-  //
-  let document_body = [];
-  let iS = document_json.credentialSubject.itemsShipped;
-  let max_rows = iS.length;
-  for (let i = 0; i < max_rows; i++) {
-    document_body[i] = {};
-
-    document_body[i].date = iS[i].description;
-    document_body[i].desc = iS[i].product.description;
-    document_body[i].price =
-      iS[i].product.productPrice.price +
-      " " +
-      iS[i].product.productPrice.priceCurrency;
-    document_body[i].unit = iS[i].product.sizeOrAmount.unitCode;
-    document_body[i].quan = iS[i].product.sizeOrAmount.value;
-    document_body[i].subtotal =
-      iS[i].lineItemTotalPrice.price +
-      " " +
-      iS[i].lineItemTotalPrice.priceCurrency;
-  }
-  document.document_body = JSON.stringify(document_body);
-
-  // 7.15 document_totals
-  //
-  let document_totals = {};
-  document_totals.subtotal =
-    document_json.credentialSubject.invoiceSubtotal.price +
-    " " +
-    document_json.credentialSubject.invoiceSubtotal.priceCurrency;
-  document_totals.total =
-    document_json.credentialSubject.totalPaymentDue.price +
-    " " +
-    document_json.credentialSubject.totalPaymentDue.priceCurrency;
-
-  document.document_totals = JSON.stringify(document_totals);
-
-  // 8.
-  // Does document_uuid already notexist in the default status table?
-  //
-  const [_8, err8] = await sub.notexist_check(
-    SELLER_DRAFT_STATUS,
-    document_uuid
-  );
-  if (err8) {
-    errno = 8;
-    console.log("Error: " + errno);
-    return res.status(400).json({ err: errno, msg: err8 });
-  }
-
-  // 9.
-  // Does document_uuid already notexist in the default document table?
-  //
-  const [_9, err9] = await sub.notexist_check(
-    SELLER_DRAFT_DOCUMENT,
-    document_uuid
-  );
-  if (err9) {
-    errno = 9;
-    console.log("Error: " + errno);
-    return res.status(400).json({ err: errno, msg: err9 });
-  }
-
-  // 10.
-  // begin Transaction
-  //
-  const [conn, _10] = await tran.connection();
-  await tran.beginTransaction(conn);
-
-  // 11.
-  // Then we go ahead and insert into the draft status
-  //
-
-  const [_11, err11] = await tran.insertStatus(
-    conn,
-    SELLER_DRAFT_STATUS,
-    status
-  );
-
-  if (err11) {
-    errno = 11;
-    insertDraftDocument;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err11, errno));
-  }
-
-  // 12.
-  // And then we need to insert into the draft document
-  //
-  const [_12, err12] = await tran.insertDraftDocument(
-    conn,
-    SELLER_DRAFT_DOCUMENT,
-    document
-  );
-
-  if (err12) {
-    console.log("err12=" + err12);
-    errno = 12;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err12, errno));
-  }
-
-  // 13.
-  // Remove from SELLER_STATUS with docunent_uuid key
-  //
-  const [_13, err13] = await tran.deleteStatus(conn, SELLER_STATUS, old_status);
-
-  if (err13) {
-    errno = 13;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err13, errno));
-  }
-
-  // 14.
-  // Remove from SELLER_DOCUMENT with docunent_uuid key
-  //
-  const [_14, err14] = await tran.deleteDocument(
-    conn,
-    SELLER_DOCUMENT,
-    old_status
-  );
-  if (err14) {
-    errno = 14;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err14, errno));
-  }
-
-  // 15.
-  // Then we go ahead and insert into the archive status
-  //
-
-  old_status.document_folder = "trash";
-  const [_15, err15] = await tran.insertStatus(
-    conn,
-    SELLER_ARCHIVE_STATUS,
-    old_status
-  );
-
-  if (err15) {
-    errno = 15;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err15, errno));
-  }
-
-  // 16.
-  // And then we need to insert into the archive document
-  //
-  const [_16, err16] = await tran.insertDocument(
-    conn,
-    SELLER_ARCHIVE_DOCUMENT,
-    old_status,
-    old_document.document_json
-  );
-
-  if (err16) {
-    errno = 16;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err16, errno));
-  }
-
-  // 17.
-  // Send 'recreate' message to buyer.
-  //
-
-  const [code17, err17] = await to_buyer.recreate(
-    buyer_host,
-    old_status.document_uuid,
-    old_status.seller_uuid
-  );
-
-  if (parseInt(code17) !== 200) {
-    errno = 17;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code17, err17, errno));
-  }
-
-  // 18.
-  // commit
-  //
-  const [_18, err18] = await tran.commit(conn);
-
-  if (err18) {
-    errno = 18;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err18, errno));
-  }
-
-  // 19.
-  //
-  conn.end();
-
-  //console.log("recreate accepted");
-
-  res.json({
-    err: 0,
-    msg: status.document_uuid,
-  });
-
-  let end = Date.now();
-  console.log("/recreate Time: %d ms", end - start);
+	const METHOD = "/recreate";
+
+	let start = Date.now();
+
+	const { document_uuid } = req.body;
+	const { member_uuid } = req.session.data;
+
+	let errno, code;
+
+	let status, document;
+
+	// 1.
+	//
+	const [buyer_uuid, err1] = await sub.getBuyerUuid(
+		SELLER_STATUS,
+		document_uuid,
+		member_uuid
+	);
+	if (err1) {
+		console.log("Error 1.1 status = 400 err=" + err1);
+
+		return res.status(400).json(err1);
+	}
+
+	// 2.
+	//
+	const [buyer_host, err2] = await sub.getBuyerHost(
+		CONTACTS,
+		member_uuid,
+		buyer_uuid
+	);
+	if (err2) {
+		console.log("Error 1.2 status = 400 err=" + err2);
+		return res.status(400).json(err2);
+	}
+
+	//3. buyer connect check
+	//
+	const [code3, err3] = await to_buyer.connect(
+		buyer_host,
+		member_uuid,
+		buyer_uuid
+	);
+
+	if (code3 !== 200) {
+		console.log("Error 3.1 status = 400 code=" + code3);
+		let msg;
+		if (code == 500) {
+			msg = { err: "buyer connect check:ECONNRESET" };
+		} else {
+			switch (err3) {
+				case "Not found.":
+					msg = { err: "The destination node cannot be found." };
+					break;
+				default:
+					msg = { err: err3 };
+					break;
+			}
+		}
+		return res.status(400).json(msg);
+	}
+
+	// 4
+	// STATUS
+	// First we go ahead and get the status.
+	//
+	const [old_status, _4] = await sub.getStatus(SELLER_STATUS, document_uuid);
+
+	if (old_status.document_uuid == null) {
+		console.log("document_uuid is null");
+
+		res.json({
+			err: 32,
+			msg: "document_uuid is null",
+		});
+		return;
+	}
+
+	// 5.
+	// Creating Draft data.
+	//
+	let prefix = "inv-";
+
+	status = JSON.parse(JSON.stringify(old_status));
+	status.document_uuid = uuidv1();
+	status.document_type = "invoice";
+	status.document_folder = "draft";
+
+	status.document_number = prefix + uniqid.time();
+	let d = new Date();
+	status.create_on = d.toISOString();
+	status.due_by = moment().add(30, "days").format("YYYY-MM-DD");
+
+	// 6.
+	// Second we go ahead and get the document
+	//
+	const [old_document, _6] = await sub.getDocument(
+		SELLER_DOCUMENT,
+		document_uuid
+	);
+
+	if (old_document.document_uuid == null) {
+		console.log("document_uuid is null");
+
+		res.json({
+			err: 42,
+			msg: "document_uuid is null",
+		});
+		return;
+	}
+
+	// 7.
+	// Creating Send data.
+	//
+
+	document = {};
+
+	// 7.1 document_uuid
+	//
+	document.document_uuid = status.document_uuid;
+
+	// 7.2 document_json
+	//
+	let document_json = JSON.parse(old_document.document_json);
+
+	document_json.credentialSubject.type = "Invoice";
+
+	// Update if customerReferenceNumber is revised.
+	//
+	// document_json.credentialSubject.customerReferenceNumber = document_json.credentialSubject.customerReferenceNumber;
+
+	document_json.credentialSubject.identifier = status.document_uuid;
+	document_json.credentialSubject.invoiceNumber = status.document_number;
+	document_json.credentialSubject.purchaseDate = status.due_by;
+	document_json.credentialSubject.invoiceDate = status.create_on;
+
+	document.document_json = JSON.stringify(document_json);
+
+	// 7.3 document_type
+	//
+	document.document_type = status.document_type;
+
+	// 7.4 subject_line
+	//
+	document.subject_line = old_status.subject_line;
+
+	// 7.5 currency_options
+	//
+	const currency_options = {
+		formatWithSymbol: true,
+		symbol: "Gwei",
+		separator: ",",
+		decimal: ".",
+		precision: 0,
+		pattern: "# !",
+	};
+	document.currency_options = JSON.stringify(currency_options);
+
+	// 7.6 seller_uuid
+	//
+	document.seller_uuid = old_status.seller_uuid;
+
+	// 7.7 seller_details
+	//
+	let seller = document_json.credentialSubject.seller;
+	let seller_details = {};
+	seller_details.organization_name = seller.name;
+	seller_details.organization_tax_id = seller.taxId;
+	seller_details.organization_department = seller.description;
+	seller_details.organization_building = seller.address.streetAddress;
+	seller_details.building = seller.address.addressLocality;
+	seller_details.addressCountry = seller.address.addressCountry;
+	seller_details.addressRegion = seller.address.addressRegion;
+	seller_details.addressCity = seller.address.addressCity;
+
+	document.seller_details = JSON.stringify(seller_details);
+
+	// 7.8 seller_membername
+	//
+	let seller_membername =
+		document_json.credentialSubject.seller.contactPoint.split("@")[0];
+	document.seller_membername = seller_membername;
+
+	// 7.9 buyer_uuid
+	//
+	document.buyer_uuid = old_status.buyer_uuid;
+
+	// 7.10 buyer_details
+	//
+	let buyer = document_json.credentialSubject.buyer;
+	let buyer_details = {};
+	buyer_details.organization_name = buyer.name;
+	buyer_details.organization_tax_id = buyer.taxId;
+	buyer_details.organization_department = buyer.description;
+	buyer_details.organization_building = buyer.address.streetAddress;
+	buyer_details.building = buyer.address.addressLocality;
+	buyer_details.addressCountry = buyer.addressCountry;
+	buyer_details.addressRegion = buyer.addressRegion;
+	buyer_details.addressCity = buyer.addressCity;
+
+	document.buyer_details = JSON.stringify(buyer_details);
+
+	// 7.11 buyer_membername
+	//
+	let buyer_membername =
+		document_json.credentialSubject.buyer.contactPoint.split("@")[0];
+	document.buyer_membername = buyer_membername;
+
+	// 7.12 create_on
+	//
+	document.create_on = status.create_on;
+
+	// 7.13 document_meta
+	//
+	document.document_meta = {};
+
+	let document_meta = {};
+	document_meta.document_number = status.document_number;
+	document_meta.created_on = status.create_on.substr(0, 10);
+	document_meta.taxId = document_json.credentialSubject.seller.taxId;
+	document_meta.due_by = status.due_by;
+
+	document.document_meta = JSON.stringify(document_meta);
+
+	// 7.14 document_body
+	//
+	let document_body = [];
+	let iS = document_json.credentialSubject.itemsShipped;
+	let max_rows = iS.length;
+	for (let i = 0; i < max_rows; i++) {
+		document_body[i] = {};
+
+		document_body[i].date = iS[i].description;
+		document_body[i].desc = iS[i].product.description;
+		document_body[i].price =
+			iS[i].product.productPrice.price +
+			" " +
+			iS[i].product.productPrice.priceCurrency;
+		document_body[i].unit = iS[i].product.sizeOrAmount.unitCode;
+		document_body[i].quan = iS[i].product.sizeOrAmount.value;
+		document_body[i].subtotal =
+			iS[i].lineItemTotalPrice.price +
+			" " +
+			iS[i].lineItemTotalPrice.priceCurrency;
+	}
+	document.document_body = JSON.stringify(document_body);
+
+	// 7.15 document_totals
+	//
+	let document_totals = {};
+	document_totals.subtotal =
+		document_json.credentialSubject.invoiceSubtotal.price +
+		" " +
+		document_json.credentialSubject.invoiceSubtotal.priceCurrency;
+	document_totals.total =
+		document_json.credentialSubject.totalPaymentDue.price +
+		" " +
+		document_json.credentialSubject.totalPaymentDue.priceCurrency;
+
+	document.document_totals = JSON.stringify(document_totals);
+
+	// 8.
+	// Does document_uuid already notexist in the default status table?
+	//
+	const [_8, err8] = await sub.notexist_check(
+		SELLER_DRAFT_STATUS,
+		document_uuid
+	);
+	if (err8) {
+		errno = 8;
+		console.log("Error: " + errno);
+		return res.status(400).json({ err: errno, msg: err8 });
+	}
+
+	// 9.
+	// Does document_uuid already notexist in the default document table?
+	//
+	const [_9, err9] = await sub.notexist_check(
+		SELLER_DRAFT_DOCUMENT,
+		document_uuid
+	);
+	if (err9) {
+		errno = 9;
+		console.log("Error: " + errno);
+		return res.status(400).json({ err: errno, msg: err9 });
+	}
+
+	// 10.
+	// begin Transaction
+	//
+	const [conn, _10] = await tran.connection();
+	await tran.beginTransaction(conn);
+
+	// 11.
+	// Then we go ahead and insert into the draft status
+	//
+
+	const [_11, err11] = await tran.insertStatus(
+		conn,
+		SELLER_DRAFT_STATUS,
+		status
+	);
+
+	if (err11) {
+		errno = 11;
+		insertDraftDocument;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err11, errno));
+	}
+
+	// 12.
+	// And then we need to insert into the draft document
+	//
+	const [_12, err12] = await tran.insertDraftDocument(
+		conn,
+		SELLER_DRAFT_DOCUMENT,
+		document
+	);
+
+	if (err12) {
+		console.log("err12=" + err12);
+		errno = 12;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err12, errno));
+	}
+
+	// 13.
+	// Remove from SELLER_STATUS with docunent_uuid key
+	//
+	const [_13, err13] = await tran.deleteStatus(conn, SELLER_STATUS, old_status);
+
+	if (err13) {
+		errno = 13;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err13, errno));
+	}
+
+	// 14.
+	// Remove from SELLER_DOCUMENT with docunent_uuid key
+	//
+	const [_14, err14] = await tran.deleteDocument(
+		conn,
+		SELLER_DOCUMENT,
+		old_status
+	);
+	if (err14) {
+		errno = 14;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err14, errno));
+	}
+
+	// 15.
+	// Then we go ahead and insert into the archive status
+	//
+
+	old_status.document_folder = "trash";
+	const [_15, err15] = await tran.insertStatus(
+		conn,
+		SELLER_ARCHIVE_STATUS,
+		old_status
+	);
+
+	if (err15) {
+		errno = 15;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err15, errno));
+	}
+
+	// 16.
+	// And then we need to insert into the archive document
+	//
+	const [_16, err16] = await tran.insertDocument(
+		conn,
+		SELLER_ARCHIVE_DOCUMENT,
+		old_status,
+		old_document.document_json
+	);
+
+	if (err16) {
+		errno = 16;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err16, errno));
+	}
+
+	// 17.
+	// Send 'recreate' message to buyer.
+	//
+
+	const [code17, err17] = await to_buyer.recreate(
+		buyer_host,
+		old_status.document_uuid,
+		old_status.seller_uuid
+	);
+
+	if (parseInt(code17) !== 200) {
+		errno = 17;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code17, err17, errno));
+	}
+
+	// 18.
+	// commit
+	//
+	const [_18, err18] = await tran.commit(conn);
+
+	if (err18) {
+		errno = 18;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err18, errno));
+	}
+
+	// 19.
+	//
+	conn.end();
+
+	//console.log("recreate accepted");
+
+	res.json({
+		err: 0,
+		msg: status.document_uuid,
+	});
+
+	let end = Date.now();
+	console.log("/recreate Time: %d ms", end - start);
 });
 
 /*
@@ -770,203 +800,203 @@ router.post("/recreate", async function (req, res) {
  * withdraw
  */
 router.post("/withdraw", async function (req, res) {
-  let start = Date.now();
+	let start = Date.now();
 
-  const { document_uuid, document_folder } = req.body;
-  const { member_uuid } = req.session.data;
+	const { document_uuid, document_folder } = req.body;
+	const { member_uuid } = req.session.data;
 
-  let errno, code;
+	let errno, code;
 
-  // 1.
-  //
-  const [buyer_uuid, err1] = await sub.getBuyerUuid(
-    SELLER_STATUS,
-    document_uuid,
-    member_uuid
-  );
+	// 1.
+	//
+	const [buyer_uuid, err1] = await sub.getBuyerUuid(
+		SELLER_STATUS,
+		document_uuid,
+		member_uuid
+	);
 
-  if (err1) {
-    console.log("Error 1 status = 400 err=" + err1);
+	if (err1) {
+		console.log("Error 1 status = 400 err=" + err1);
 
-    return res.status(400).json(err1);
-  }
+		return res.status(400).json(err1);
+	}
 
-  // 2.
-  const [buyer_host, err2] = await sub.getBuyerHost(
-    CONTACTS,
-    member_uuid,
-    buyer_uuid
-  );
+	// 2.
+	const [buyer_host, err2] = await sub.getBuyerHost(
+		CONTACTS,
+		member_uuid,
+		buyer_uuid
+	);
 
-  if (err2) {
-    console.log("Error 2 status = 400 err=" + err2);
-    return res.status(400).json(err2);
-  }
+	if (err2) {
+		console.log("Error 2 status = 400 err=" + err2);
+		return res.status(400).json(err2);
+	}
 
-  //3. buyer connect check
-  const [code3, err3] = await to_buyer.connect(
-    buyer_host,
-    member_uuid,
-    buyer_uuid
-  );
+	//3. buyer connect check
+	const [code3, err3] = await to_buyer.connect(
+		buyer_host,
+		member_uuid,
+		buyer_uuid
+	);
 
-  if (code3 !== 200) {
-    console.log("Error 3 status = 400 code=" + code3);
-    let msg;
-    if (code3 == 500) {
-      msg = { err: "buyer connect check:ECONNRESET" };
-    } else {
-      switch (err3) {
-        case "Not found.":
-          msg = { err: "The destination node cannot be found." };
-          break;
-        default:
-          msg = { err: err3 };
-          break;
-      }
-    }
-    return res.status(400).json(msg);
-  }
+	if (code3 !== 200) {
+		console.log("Error 3 status = 400 code=" + code3);
+		let msg;
+		if (code3 == 500) {
+			msg = { err: "buyer connect check:ECONNRESET" };
+		} else {
+			switch (err3) {
+				case "Not found.":
+					msg = { err: "The destination node cannot be found." };
+					break;
+				default:
+					msg = { err: err3 };
+					break;
+			}
+		}
+		return res.status(400).json(msg);
+	}
 
-  // 4
-  // STATUS
-  // First we go ahead and get the status.
-  //
-  const [old_status, _4] = await sub.getStatus(SELLER_STATUS, document_uuid);
+	// 4
+	// STATUS
+	// First we go ahead and get the status.
+	//
+	const [old_status, _4] = await sub.getStatus(SELLER_STATUS, document_uuid);
 
-  // Does record exist?
-  if (old_status.document_uuid == null) {
-    console.log("document_uuid is null");
-    errno = 4;
+	// Does record exist?
+	if (old_status.document_uuid == null) {
+		console.log("document_uuid is null");
+		errno = 4;
 
-    let msg = { err: errno, msg: document_uuid };
+		let msg = { err: errno, msg: document_uuid };
 
-    return res.status(400).json(msg);
-  }
+		return res.status(400).json(msg);
+	}
 
-  // 5.
-  // Does document_uuid already exist in the status table?
-  //
-  const [_5, err5] = await sub.exist_check(SELLER_STATUS, document_uuid);
+	// 5.
+	// Does document_uuid already exist in the status table?
+	//
+	const [_5, err5] = await sub.exist_check(SELLER_STATUS, document_uuid);
 
-  if (err5) {
-    console.log("Error 5 status = 400 code=" + err5);
-    errno = 5;
-    return res.status(400).json({ err: err5, code: errno });
-  }
+	if (err5) {
+		console.log("Error 5 status = 400 code=" + err5);
+		errno = 5;
+		return res.status(400).json({ err: err5, code: errno });
+	}
 
-  // 6.
-  // Does document_uuid already exist in the document table?
-  //
-  const [_6, err6] = await sub.exist_check(SELLER_DOCUMENT, document_uuid);
+	// 6.
+	// Does document_uuid already exist in the document table?
+	//
+	const [_6, err6] = await sub.exist_check(SELLER_DOCUMENT, document_uuid);
 
-  if (err6) {
-    console.log("Error 6 status = 400 code=" + err6);
-    errno = 6;
-    return res.status(400).json({ err: err6, code: errno });
-  }
+	if (err6) {
+		console.log("Error 6 status = 400 code=" + err6);
+		errno = 6;
+		return res.status(400).json({ err: err6, code: errno });
+	}
 
-  // 7.
-  // begin Transaction
-  //
-  const [conn, _7] = await tran.connection();
-  await tran.beginTransaction(conn);
+	// 7.
+	// begin Transaction
+	//
+	const [conn, _7] = await tran.connection();
+	await tran.beginTransaction(conn);
 
-  // 8.
-  // update status
-  //
+	// 8.
+	// update status
+	//
 
-  const [_8, err8] = await tran.setWithdrawSeller(
-    conn,
-    SELLER_STATUS,
-    document_uuid,
-    member_uuid,
-    document_folder
-  );
+	const [_8, err8] = await tran.setWithdrawSeller(
+		conn,
+		SELLER_STATUS,
+		document_uuid,
+		member_uuid,
+		document_folder
+	);
 
-  if (err8) {
-    console.log("Error 8 status = 400 code=" + err8.msg);
-    errno = 8;
-    code = 400;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code, err8, errno));
-  }
+	if (err8) {
+		console.log("Error 8 status = 400 code=" + err8.msg);
+		errno = 8;
+		code = 400;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code, err8, errno));
+	}
 
-  // 9.
-  // Send 'withdraw" message to buyer.
-  //
+	// 9.
+	// Send 'withdraw" message to buyer.
+	//
 
-  const [code9, err9] = await to_buyer.withdraw(
-    buyer_host,
-    old_status.document_uuid,
-    old_status.buyer_uuid,
-    document_folder
-  );
+	const [code9, err9] = await to_buyer.withdraw(
+		buyer_host,
+		old_status.document_uuid,
+		old_status.buyer_uuid,
+		document_folder
+	);
 
-  if (code9 !== 200) {
-    console.log("Error 9 status = 400 code=" + err9);
-    errno = 9;
-    return res
-      .status(400)
-      .json(tran.rollbackAndReturn(conn, code9, err9, errno));
-  }
+	if (code9 !== 200) {
+		console.log("Error 9 status = 400 code=" + err9);
+		errno = 9;
+		return res
+			.status(400)
+			.json(tran.rollbackAndReturn(conn, code9, err9, errno));
+	}
 
-  // 10
-  // commit
-  //
-  const [_10, err10] = await tran.commit(conn);
+	// 10
+	// commit
+	//
+	const [_10, err10] = await tran.commit(conn);
 
-  if (err10) {
-    console.log("Error 10 status = 400 code=" + err10);
-    errno = 10;
-    code = 400;
-    let msg = tran.rollbackAndReturn(conn, code, err10, errno);
+	if (err10) {
+		console.log("Error 10 status = 400 code=" + err10);
+		errno = 10;
+		code = 400;
+		let msg = tran.rollbackAndReturn(conn, code, err10, errno);
 
-    // 11.
-    //
-    const [seller_host, err11] = await sub.getSellerHost(
-      CONTACTS,
-      member_uuid,
-      buyer_uuid
-    );
+		// 11.
+		//
+		const [seller_host, err11] = await sub.getSellerHost(
+			CONTACTS,
+			member_uuid,
+			buyer_uuid
+		);
 
-    if (err11) {
-      console.log("Error 11 status = 400 err=" + err11);
-      return res.status(400).json(err11);
-    }
+		if (err11) {
+			console.log("Error 11 status = 400 err=" + err11);
+			return res.status(400).json(err11);
+		}
 
-    // 12.
-    //
-    const [code12, err12] = await to_buyer.rollbackReturnToSent(
-      seller_host,
-      buyer_uuid,
-      member_uuid
-    );
+		// 12.
+		//
+		const [code12, err12] = await to_buyer.rollbackReturnToSent(
+			seller_host,
+			buyer_uuid,
+			member_uuid
+		);
 
-    if (code12 !== 200) {
-      console.log("Error 12 code=" + code12 + ":err=" + err12);
-      if (code12 == 500) {
-        msg = { err: "seller connect check:ECONNRESET" };
-      } else {
-        msg = { err: err12 };
-      }
-    }
+		if (code12 !== 200) {
+			console.log("Error 12 code=" + code12 + ":err=" + err12);
+			if (code12 == 500) {
+				msg = { err: "seller connect check:ECONNRESET" };
+			} else {
+				msg = { err: err12 };
+			}
+		}
 
-    return res.status(400).json(msg);
-  }
+		return res.status(400).json(msg);
+	}
 
-  // 13.
-  //
-  conn.end();
+	// 13.
+	//
+	conn.end();
 
-  //console.log("/withdraw accepted");
+	//console.log("/withdraw accepted");
 
-  res.json({
-    err: 0,
-    msg: document_uuid,
-  });
+	res.json({
+		err: 0,
+		msg: document_uuid,
+	});
 
-  let end = Date.now();
-  console.log("/withdraw Time: %d ms", end - start);
+	let end = Date.now();
+	console.log("/withdraw Time: %d ms", end - start);
 });

--- a/routes/seller_invoice.js
+++ b/routes/seller_invoice.js
@@ -21,39 +21,63 @@
 "use strict";
 
 // Import sub
-const sub						= require("./invoice_sub.js");
-const to_buyer					= require("./seller_to_buyer.js");
-const tran						= require("./invoice_sub_transaction.js");
-
+const sub = require("./invoice_sub.js");
+const to_buyer = require("./seller_to_buyer.js");
+const tran = require("./invoice_sub_transaction.js");
 
 // Import Router
-const express					= require('express');
-const router					= express.Router();
-module.exports					= router;
+const express = require("express");
+const router = express.Router();
+module.exports = router;
 
 // Libraries
 
-const uuidv1					= require('uuid').v1;
-const uniqid					= require('uniqid');
-const moment					= require('moment');
+const uuidv1 = require("uuid").v1;
+const uniqid = require("uniqid");
+const moment = require("moment");
 
 // import Sign
-const sign_your_credentials           = require("./sign_your_credentials.js");
 
-// Database 
+const db = require("../database.js");
+const sign_your_credentials = require("./sign_your_credentials.js");
+const { makePresentation } = require("../modules/presentations_out.js");
+
+// Database
 
 // Table Name
-const SELLER_DRAFT_DOCUMENT		= "seller_document_draft";
-const SELLER_DRAFT_STATUS		= "seller_status_draft";
+const SELLER_DRAFT_DOCUMENT = "seller_document_draft";
+const SELLER_DRAFT_STATUS = "seller_status_draft";
 
-const SELLER_DOCUMENT			= "seller_document";
-const SELLER_STATUS				= "seller_status";
+const SELLER_DOCUMENT = "seller_document";
+const SELLER_STATUS = "seller_status";
 
-const SELLER_ARCHIVE_DOCUMENT	= "seller_document_archive";
-const SELLER_ARCHIVE_STATUS		= "seller_status_archive";
+const SELLER_ARCHIVE_DOCUMENT = "seller_document_archive";
+const SELLER_ARCHIVE_STATUS = "seller_status_archive";
 
-const CONTACTS	  				= "contacts"
+const CONTACTS = "contacts";
 
+const getPrivateKeys = async (member_did) => {
+  const sql = `
+		SELECT
+			public_key
+		FROM
+			privatekeys
+		WHERE
+			member_did = ?
+	`;
+
+  const args = [member_did];
+
+  let row;
+  try {
+    row = await db.selectOne(sql, args);
+  } catch (err) {
+    return [null, err];
+  }
+
+  const keyPair = JSON.parse(row.public_key);
+  return [keyPair, null];
+};
 
 // ------------------------------- End Points -------------------------------
 
@@ -61,765 +85,888 @@ const CONTACTS	  				= "contacts"
  * [ Send Invoice ]
  * send
  */
-router.post('/send', async function(req, res) {
-	const METHOD = "/send";
 
-	let start = Date.now();
+router.post("/send", async function (req, res) {
+  const start = Date.now();
 
-	const { document_uuid } = req.body;
-	const { member_uuid } = req.session.data;
+  const { document_uuid } = req.body;
+  const { member_uuid } = req.session.data;
 
-	let code , errno;
+  let code, errno;
 
-	// 1.
-	const [ buyer_uuid, err1 ] = await sub.getBuyerUuidForDraft(SELLER_DRAFT_STATUS, document_uuid, member_uuid);
-	if(err1) {
-		console.log("Error 1.1 status = 400 err="+err1+":"+document_uuid +":"+ member_uuid);
+  // 1.
+  const [buyer_uuid, err1] = await sub.getBuyerUuidForDraft(
+    SELLER_DRAFT_STATUS,
+    document_uuid,
+    member_uuid
+  );
+  if (err1) {
+    console.log(
+      "Error 1.1 status = 400 err=" +
+        err1 +
+        ":" +
+        document_uuid +
+        ":" +
+        member_uuid
+    );
 
-		return res.status(400).json(err1);
-	}
-	if( buyer_uuid == null) {
-		console.log("Error 1.2 :"+document_uuid +":"+ member_uuid);
-		return res.status(400).json({err:1,msg:'buyer_uuid is not found'});
-	}
+    return res.status(400).json(err1);
+  }
+  if (buyer_uuid == null) {
+    console.log("Error 1.2 :" + document_uuid + ":" + member_uuid);
+    return res.status(400).json({ err: 1, msg: "buyer_uuid is not found" });
+  }
 
-	// 2.
-	const [ buyer_host, err2 ] = await sub.getBuyerHost(CONTACTS, member_uuid, buyer_uuid);
-	if(err2) {
-		console.log("Error 2 status = 400 err="+err2+":"+member_uuid +":"+ buyer_uuid);
-		return res.status(400).json(err2);
-	}
+  // 2.
+  const [buyer_host, err2] = await sub.getBuyerHost(
+    CONTACTS,
+    member_uuid,
+    buyer_uuid
+  );
+  if (err2) {
+    console.log(
+      "Error 2 status = 400 err=" + err2 + ":" + member_uuid + ":" + buyer_uuid
+    );
+    return res.status(400).json(err2);
+  }
 
-	//3. buyer connect check
-	const [ code3 , err3 ] = await to_buyer.connect(buyer_host, member_uuid, buyer_uuid);
+  // 4.
+  // DRAFT_STATUS
+  // First we go ahead and get the draft status.
+  //
+  const [status, _4] = await sub.getStatus(SELLER_DRAFT_STATUS, document_uuid);
 
-	if(code3 !== 200) {
-		console.log("Error 3 code="+code3+":err="+err3);
-		let msg;
-		if(code == 500) {
-			msg = {"err":"buyer connect check:ECONNRESET"};
-		} else {
-			switch(err3) {
-			case "Not found.":
-				msg = {"err":"The destination node cannot be found."};
-			break;
-			default:
-				msg = {"err":err3};
-			break;
-			}
-		}
-		return res.status(400).json(msg);
-	}
+  if (status.document_uuid == null) {
+    console.log("document_uuid is null");
 
-	// 4. 
-	// DRAFT_STATUS
-	// First we go ahead and get the draft status.
-	//
-	const [ status , _4 ] = await sub.getStatus( SELLER_DRAFT_STATUS, document_uuid) ;
+    res.json({ err: 4, msg: "document_uuid is null" });
+    return;
+  }
 
-	if(status.document_uuid == null) {
-		console.log("document_uuid is null")
+  // 5.
+  // Creating Send data.
+  //
+  status.document_uuid = document_uuid;
+  status.document_type = "invoice";
+  status.document_folder = "sent";
 
-		res.json({ err : 4, msg : 'document_uuid is null' });
-		return;
-	}
+  // 6.
+  // Second we go ahead and get the draft document
+  //
+  const [document] = await sub.getDraftDocumentForSend(
+    SELLER_DRAFT_DOCUMENT,
+    document_uuid
+  );
 
-	// 5.
-	// Creating Send data.
-	//
-	status.document_uuid	= document_uuid;
-	status.document_type	= 'invoice';
-	status.document_folder	= 'sent';
+  if (document.document_uuid == null) {
+    console.log("document_uuid is null");
 
+    res.json({ err: 6, msg: "document_uuid is null" });
+    return;
+  }
 
-	// 6.
-	// Second we go ahead and get the draft document
-	//
-	const [ document , _6 ] = await sub.getDraftDocumentForSend( SELLER_DRAFT_DOCUMENT, document_uuid) ;
+  document.seller_uuid = member_uuid;
+  document.buyer_uuid = buyer_uuid;
 
-	if(document.document_uuid == null) {
-		console.log("document_uuid is null")
+  // 7.
+  // signInvoice
+  //
 
-		res.json({ err : 6, msg : 'document_uuid is null' });
-		return;
-	}
+  const signedCredential = await sign_your_credentials.signInvoice(
+    document.document_uuid,
+    document.document_json
+  );
+  const document_json = JSON.stringify(signedCredential);
 
-	document.seller_uuid	= member_uuid;
-	document.buyer_uuid		= buyer_uuid;
+  document.document_json = document_json;
 
-	// 7.
-	// signInvoice
-	//
-	
-	const signedCredential = await sign_your_credentials.signInvoice(document.document_uuid, document.document_json);
-	const document_json = JSON.stringify(signedCredential); 
+  if (document.document_json == null) {
+    console.log("document_json == null");
 
-	document.document_json = document_json;
+    res.json({ err: 7, msg: "document_json is null" });
+    return;
+  }
 
-	if( document.document_json == null) {
-		console.log("document_json == null");
+  // 8.
+  // Does document_uuid already notexist in the status table?
+  //
+  const [_8, err8] = await sub.notexist_check(SELLER_STATUS, document_uuid);
+  if (err8) {
+    errno = 8;
+    console.log("Error: " + errno);
+    return res.status(400).json({ err: errno, msg: err8 });
+  }
 
-		res.json({ err : 7, msg : 'document_json is null'});
-		return;
-	}
+  // 9.
+  // Does document_uuid already notexist in the document table?
+  //
+  const [_9, err9] = await sub.notexist_check(SELLER_DOCUMENT, document_uuid);
+  if (err9) {
+    errno = 9;
+    console.log("Error: " + errno);
+    return res.status(400).json({ err: errno, msg: err9 });
+  }
 
-	// 8.
-	// Does document_uuid already notexist in the status table?
-	//
-	const [ _8 , err8 ] = await sub.notexist_check( SELLER_STATUS, document_uuid)
-	if ( err8 ) {
-		errno = 8;
-		console.log("Error: "+errno);
-		return res.status(400).json({ err : errno, msg : err8 });
-	}
+  // 10.
+  // begin Transaction
+  //
+  const [conn, _10] = await tran.connection();
+  await tran.beginTransaction(conn);
 
-	// 9.
-	// Does document_uuid already notexist in the document table?
-	//
-	const [ _9 , err9 ] = await sub.notexist_check( SELLER_DOCUMENT, document_uuid)
-	if ( err9 ) {
-		errno = 9;
-		console.log("Error: "+errno);
-		return res.status(400).json({ err : errno, msg : err9 });
-	}
+  // 11.
+  // Then we go ahead and insert into the status
+  //
+  const [_11, err11] = await tran.insertStatus(conn, SELLER_STATUS, status);
 
-	// 10.
-	// begin Transaction
-	//
-	const [ conn , _10 ] = await tran.connection ();
-	await tran.beginTransaction(conn);
+  if (err11) {
+    errno = 11;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err11, errno));
+  }
 
-	// 11.
-	// Then we go ahead and insert into the status
-	//
-	const [ _11 , err11 ] = await tran.insertStatus(conn, SELLER_STATUS, status);
+  // 12.
+  // And then we need to insert into database
+  //
+  const [_12, err12] = await tran.insertDocument(
+    conn,
+    SELLER_DOCUMENT,
+    status,
+    document_json
+  );
+  if (err12) {
+    errno = 12;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err12, errno));
+  }
 
-	if ( err11 ) {
-		errno = 11;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err11, errno));
-	}
+  // 13.
+  // Remove from SELLER_DRAFT_STATUS with docunent_uuid key
+  //
+  const [_13, err13] = await tran.deleteStatus(
+    conn,
+    SELLER_DRAFT_STATUS,
+    status
+  );
+  if (err13) {
+    errno = 13;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err13, errno));
+  }
 
+  // 14.
+  // Remove from SELLER_DRAFT_DOCUMENT with docunent_uuid key
+  //
+  const [_14, err14] = await tran.deleteDocument(
+    conn,
+    SELLER_DRAFT_DOCUMENT,
+    status
+  );
+  if (err14) {
+    errno = 14;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err14, errno));
+  }
 
-	// 12.
-	// And then we need to insert into database
-	//
-	const [ _12, err12 ] = await tran.insertDocument(conn, SELLER_DOCUMENT, status, document_json);
-	if (err12 ) {
-		errno = 12;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err12, errno));
-	}
+  // 15.
+  // Send 'send' message to buyer.
 
-	// 13.
-	// Remove from SELLER_DRAFT_STATUS with docunent_uuid key
-	//
-	const [ _13, err13 ] = await tran.deleteStatus(conn, SELLER_DRAFT_STATUS, status) ;
-	if ( err13 ) {
-		errno = 13;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err13, errno));
-	}
+  const presenationSlug = "/api/presentations/available";
+  const url = buyer_host + presenationSlug;
 
-	// 14.
-	// Remove from SELLER_DRAFT_DOCUMENT with docunent_uuid key
-	//
-	const [ _14, err14 ] = await tran.deleteDocument(conn, SELLER_DRAFT_DOCUMENT, status) ;
-	if (err14 ) {
-		errno = 14;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err14, errno));
-	}
+  const [keyPair] = await getPrivateKeys(member_uuid);
+  const vc = JSON.parse(document.document_json);
+  const [code15, err15] = await makePresentation(url, keyPair, vc);
 
+  if (err15) {
+    console.log("OMG nuuuu it failed");
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code15, 15, errno));
+  }
 
-	// 15.
-	// Send 'send' message to buyer.
-	//
-	const [ code15, err15 ] = await to_buyer.sendInvoice(buyer_host, document, status);
-	//console.log(code);
-	//console.log(err);
+  // 16.
+  // commit
+  //
+  const [_16, err16] = await tran.commit(conn);
 
-	if(parseInt(code15) !== 200) {
-		errno = 15;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code15, err15, errno));
-	}
+  if (err16) {
+    errno = 16;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err16, errno));
+  }
 
-	// 16.
-	// commit
-	//
-	const [ _16, err16 ] = await tran.commit(conn);
+  // 17.
+  //
+  conn.end();
 
-	if (err16) {
-		errno = 16;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err16, errno));
-	}
+  //console.log("/send accepted");
 
-	// 17.
-	//
-	conn.end();
+  res.json({
+    err: 0,
+    msg: status.document_uuid,
+  });
 
-	//console.log("/send accepted");
-
-
-	res.json({
-		err : 0,
-		msg : status.document_uuid
-	});
-
-	let end = Date.now();
-	console.log("/send Time: %d ms", end - start);
-
+  const end = Date.now();
+  console.log("/send Time: %d ms", end - start);
 });
 
-
 /*
-* [ Move to Draft ] 
-*/
-router.post('/recreate', async function(req, res) {
-
-	const METHOD = "/recreate";
-
-	let start = Date.now();
-
-	const { document_uuid } = req.body;
-	const { member_uuid } = req.session.data;
-
-	let errno , code;
-
-	let status,  document;
-
-	// 1.
-	//
-	const [ buyer_uuid, err1 ] = await sub.getBuyerUuid(SELLER_STATUS, document_uuid, member_uuid);
-	if(err1) {
-		console.log("Error 1.1 status = 400 err="+err1);
-
-		return res.status(400).json(err1);
-	}
-
-	// 2.
-	//
-	const [ buyer_host, err2 ] = await sub.getBuyerHost(CONTACTS, member_uuid, buyer_uuid);
-	if(err2) {
-		console.log("Error 1.2 status = 400 err="+err2);
-		return res.status(400).json(err2);
-	}
-
-	//3. buyer connect check
-	//
-	const [ code3, err3 ] = await to_buyer.connect(buyer_host, member_uuid, buyer_uuid);
-
-	if( code3 !== 200) {
-		console.log("Error 3.1 status = 400 code="+code3);
-		let msg;
-		if(code == 500) {
-			msg = {"err":"buyer connect check:ECONNRESET"};
-		} else {
-			switch(err3) {
-			case "Not found.":
-				msg = {"err":"The destination node cannot be found."};
-			break;
-			default:
-				msg = {"err":err3};
-			break;
-			}
-		}
-		return res.status(400).json(msg);
-	}
-
-	// 4
-	// STATUS
-	// First we go ahead and get the status.
-	//
-	const [ old_status , _4 ] = await sub.getStatus( SELLER_STATUS, document_uuid) ;
-
-	if(old_status.document_uuid == null) {
-		console.log("document_uuid is null")
-
-		res.json({
-			err : 32,
-			msg : 'document_uuid is null'
-		});
-		return;
-	}
-
-	// 5.
-	// Creating Draft data.
-	//
-	let prefix = "inv-";
-
-	status = JSON.parse(JSON.stringify(old_status));
-	status.document_uuid	= uuidv1();
-	status.document_type	= 'invoice';
-	status.document_folder  = 'draft';
-
-	status.document_number = prefix + uniqid.time();
-	let d = new Date();
-	status.create_on = d.toISOString()
-	status.due_by = moment().add(30, 'days').format('YYYY-MM-DD');
-
-	// 6.
-	// Second we go ahead and get the document
-	//
-	const [ old_document , _6 ] = await sub.getDocument( SELLER_DOCUMENT, document_uuid) ;
-
-	if(old_document.document_uuid == null) {
-		console.log("document_uuid is null")
-
-		res.json({
-			err : 42,
-			msg : 'document_uuid is null'
-		});
-		return;
-	}
-
-	// 7.
-	// Creating Send data.
-	//
-
-	document = {};
-
-// 7.1 document_uuid
-//
-	document.document_uuid = status.document_uuid;
-
-// 7.2 document_json
-//
-	let document_json = JSON.parse(old_document.document_json);
-
-	document_json.credentialSubject.type = 'Invoice';
-
-	// Update if customerReferenceNumber is revised.
-	//
-	// document_json.credentialSubject.customerReferenceNumber = document_json.credentialSubject.customerReferenceNumber;
-
-	document_json.credentialSubject.identifier = status.document_uuid;
-	document_json.credentialSubject.invoiceNumber = status.document_number;
-	document_json.credentialSubject.purchaseDate = status.due_by;
-	document_json.credentialSubject.invoiceDate = status.create_on;
-
-	document.document_json = JSON.stringify(document_json);
-
-// 7.3 document_type
-//
-	document.document_type = status.document_type;
-
-// 7.4 subject_line
-//
-	document.subject_line = old_status.subject_line;
-
-// 7.5 currency_options
-//
-	const currency_options = {"formatWithSymbol":true,"symbol":"Gwei","separator":",","decimal":".","precision":0,"pattern":"# !"}
-	document.currency_options = JSON.stringify(currency_options);
-
-// 7.6 seller_uuid
-//
-	document.seller_uuid = old_status.seller_uuid;
-
-// 7.7 seller_details
-//
-	let seller = document_json.credentialSubject.seller;
-	let seller_details = {}
-	seller_details.organization_name = seller.name;
-	seller_details.organization_tax_id = seller.taxId;
-	seller_details.organization_department = seller.description;
-	seller_details.organization_building = seller.address.streetAddress;
-	seller_details.building = seller.address.addressLocality;
-	seller_details.addressCountry = seller.address.addressCountry;
-	seller_details.addressRegion = seller.address.addressRegion;
-	seller_details.addressCity = seller.address.addressCity;
-
-	document.seller_details = JSON.stringify(seller_details);
-
-// 7.8 seller_membername
-//
-	let seller_membername = document_json.credentialSubject.seller.contactPoint.split("@")[0];
-	document.seller_membername = seller_membername;
-
-// 7.9 buyer_uuid
-//
-	document.buyer_uuid = old_status.buyer_uuid;
-
-// 7.10 buyer_details
-//
-	let buyer = document_json.credentialSubject.buyer;
-	let buyer_details = {}
-	buyer_details.organization_name = buyer.name;
-	buyer_details.organization_tax_id = buyer.taxId;
-	buyer_details.organization_department = buyer.description;
-	buyer_details.organization_building = buyer.address.streetAddress;
-	buyer_details.building = buyer.address.addressLocality;
-	buyer_details.addressCountry = buyer.addressCountry;
-	buyer_details.addressRegion = buyer.addressRegion;
-	buyer_details.addressCity = buyer.addressCity;
-
-	document.buyer_details = JSON.stringify(buyer_details);
-
-// 7.11 buyer_membername
-//
-	let buyer_membername = document_json.credentialSubject.buyer.contactPoint.split("@")[0];
-	document.buyer_membername = buyer_membername;
-
-// 7.12 create_on
-//
-	document.create_on = status.create_on;
-
-// 7.13 document_meta
-//
-	document.document_meta = {};
-
-	let document_meta =  {}
-	document_meta.document_number = status.document_number;
-	document_meta.created_on = status.create_on.substr(0,10);
-	document_meta.taxId = document_json.credentialSubject.seller.taxId;
-	document_meta.due_by = status.due_by;
-
-	document.document_meta = JSON.stringify(document_meta);
-
-// 7.14 document_body
-//
-	let document_body = [];
-	let iS = document_json.credentialSubject.itemsShipped;
-	let max_rows = iS.length;
-	for ( let i = 0; i< max_rows; i++) {
-		document_body[i] = {};
-
-		document_body[i].date	= iS[i].description;
-		document_body[i].desc	= iS[i].product.description;
-		document_body[i].price	= iS[i].product.productPrice.price +" "+ iS[i].product.productPrice.priceCurrency;
-		document_body[i].unit	= iS[i].product.sizeOrAmount.unitCode;
-		document_body[i].quan	= iS[i].product.sizeOrAmount.value;
-		document_body[i].subtotal= iS[i].lineItemTotalPrice.price +" "+iS[i].lineItemTotalPrice.priceCurrency;
-		
-	}
-	document.document_body = JSON.stringify(document_body);
-
-
-// 7.15 document_totals
-//
-	let document_totals = {}
-	document_totals.subtotal = document_json.credentialSubject.invoiceSubtotal.price +" "+document_json.credentialSubject.invoiceSubtotal.priceCurrency;
-	document_totals.total = document_json.credentialSubject.totalPaymentDue.price +" "+document_json.credentialSubject.totalPaymentDue.priceCurrency;
-
-	document.document_totals = JSON.stringify(document_totals);
-
-
-	// 8.
-	// Does document_uuid already notexist in the default status table?
-	//
-	const [ _8, err8 ] = await sub.notexist_check( SELLER_DRAFT_STATUS, document_uuid)
-	if (err8 ) {
-		errno = 8;
-		console.log("Error: "+errno);
-		return res.status(400).json({ err : errno, msg : err8 });
-	}
-
-	// 9.
-	// Does document_uuid already notexist in the default document table?
-	//
-	const [ _9, err9 ] = await sub.notexist_check( SELLER_DRAFT_DOCUMENT, document_uuid)
-	if (err9 ) {
-		errno = 9;
-		console.log("Error: "+errno);
-		return res.status(400).json({ err : errno, msg : err9 });
-	}
-
-	// 10. 
-	// begin Transaction
-	//
-	const [ conn , _10 ] = await tran.connection ();
-	await tran.beginTransaction(conn);
-
-	// 11.
-	// Then we go ahead and insert into the draft status
-	//
-
-	const [ _11, err11 ] = await tran.insertStatus(conn, SELLER_DRAFT_STATUS, status);
-
-	if (err11 ) {
-		errno = 11;insertDraftDocument
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err11, errno));
-	}
-
-	// 12.
-	// And then we need to insert into the draft document 
-	//
-	const [ _12, err12 ] = await tran.insertDraftDocument(conn, SELLER_DRAFT_DOCUMENT, document);
-
-	if (err12 ) {
-		console.log("err12="+err12)
-		errno = 12;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err12, errno));
-	}
-
-	// 13.
-	// Remove from SELLER_STATUS with docunent_uuid key
-	//
-	const [ _13, err13 ] = await tran.deleteStatus(conn, SELLER_STATUS, old_status) ;
-
-	if (err13 ) {
-		errno = 13;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err13, errno));
-	}
-
-	// 14.
-	// Remove from SELLER_DOCUMENT with docunent_uuid key
-	//
-	const [ _14 , err14 ] = await tran.deleteDocument(conn, SELLER_DOCUMENT, old_status) ;
-	if(err14) {
-		errno = 14;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err14, errno));
-	}
-
-	// 15.
-	// Then we go ahead and insert into the archive status
-	//
-
-	old_status.document_folder  = 'trash';
-	const [ _15, err15] = await tran.insertStatus(conn, SELLER_ARCHIVE_STATUS, old_status);
-
-	if(err15) {
-		errno = 15;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err15, errno));
-	}
-
-	// 16.
-	// And then we need to insert into the archive document 
-	//
-	const [ _16 , err16 ] = await tran.insertDocument(conn, SELLER_ARCHIVE_DOCUMENT, old_status, old_document.document_json);
-
-	if(err16) {
-		errno = 16;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err16, errno));
-	}
-
-	// 17.
-	// Send 'recreate' message to buyer.
-	//
-
-	const [ code17, err17 ] = await to_buyer.recreate(buyer_host, old_status.document_uuid, old_status.seller_uuid);
-
-	if(parseInt(code17) !== 200) {
-		errno = 17;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code17, err17, errno));
-	}
-
-	// 18.
-	// commit
-	//
-	const [ _18, err18 ] = await tran.commit(conn);
-
-	if (err18) {
-		errno = 18;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err18, errno));
-
-	}
-
-	// 19.
-	//
-	conn.end();
-
-	//console.log("recreate accepted");
-
-	res.json({
-		err : 0,
-		msg : status.document_uuid
-	});
-
-	let end = Date.now();
-	console.log("/recreate Time: %d ms", end - start);
-
+ * [ Move to Draft ]
+ */
+router.post("/recreate", async function (req, res) {
+  const METHOD = "/recreate";
+
+  let start = Date.now();
+
+  const { document_uuid } = req.body;
+  const { member_uuid } = req.session.data;
+
+  let errno, code;
+
+  let status, document;
+
+  // 1.
+  //
+  const [buyer_uuid, err1] = await sub.getBuyerUuid(
+    SELLER_STATUS,
+    document_uuid,
+    member_uuid
+  );
+  if (err1) {
+    console.log("Error 1.1 status = 400 err=" + err1);
+
+    return res.status(400).json(err1);
+  }
+
+  // 2.
+  //
+  const [buyer_host, err2] = await sub.getBuyerHost(
+    CONTACTS,
+    member_uuid,
+    buyer_uuid
+  );
+  if (err2) {
+    console.log("Error 1.2 status = 400 err=" + err2);
+    return res.status(400).json(err2);
+  }
+
+  //3. buyer connect check
+  //
+  const [code3, err3] = await to_buyer.connect(
+    buyer_host,
+    member_uuid,
+    buyer_uuid
+  );
+
+  if (code3 !== 200) {
+    console.log("Error 3.1 status = 400 code=" + code3);
+    let msg;
+    if (code == 500) {
+      msg = { err: "buyer connect check:ECONNRESET" };
+    } else {
+      switch (err3) {
+        case "Not found.":
+          msg = { err: "The destination node cannot be found." };
+          break;
+        default:
+          msg = { err: err3 };
+          break;
+      }
+    }
+    return res.status(400).json(msg);
+  }
+
+  // 4
+  // STATUS
+  // First we go ahead and get the status.
+  //
+  const [old_status, _4] = await sub.getStatus(SELLER_STATUS, document_uuid);
+
+  if (old_status.document_uuid == null) {
+    console.log("document_uuid is null");
+
+    res.json({
+      err: 32,
+      msg: "document_uuid is null",
+    });
+    return;
+  }
+
+  // 5.
+  // Creating Draft data.
+  //
+  let prefix = "inv-";
+
+  status = JSON.parse(JSON.stringify(old_status));
+  status.document_uuid = uuidv1();
+  status.document_type = "invoice";
+  status.document_folder = "draft";
+
+  status.document_number = prefix + uniqid.time();
+  let d = new Date();
+  status.create_on = d.toISOString();
+  status.due_by = moment().add(30, "days").format("YYYY-MM-DD");
+
+  // 6.
+  // Second we go ahead and get the document
+  //
+  const [old_document, _6] = await sub.getDocument(
+    SELLER_DOCUMENT,
+    document_uuid
+  );
+
+  if (old_document.document_uuid == null) {
+    console.log("document_uuid is null");
+
+    res.json({
+      err: 42,
+      msg: "document_uuid is null",
+    });
+    return;
+  }
+
+  // 7.
+  // Creating Send data.
+  //
+
+  document = {};
+
+  // 7.1 document_uuid
+  //
+  document.document_uuid = status.document_uuid;
+
+  // 7.2 document_json
+  //
+  let document_json = JSON.parse(old_document.document_json);
+
+  document_json.credentialSubject.type = "Invoice";
+
+  // Update if customerReferenceNumber is revised.
+  //
+  // document_json.credentialSubject.customerReferenceNumber = document_json.credentialSubject.customerReferenceNumber;
+
+  document_json.credentialSubject.identifier = status.document_uuid;
+  document_json.credentialSubject.invoiceNumber = status.document_number;
+  document_json.credentialSubject.purchaseDate = status.due_by;
+  document_json.credentialSubject.invoiceDate = status.create_on;
+
+  document.document_json = JSON.stringify(document_json);
+
+  // 7.3 document_type
+  //
+  document.document_type = status.document_type;
+
+  // 7.4 subject_line
+  //
+  document.subject_line = old_status.subject_line;
+
+  // 7.5 currency_options
+  //
+  const currency_options = {
+    formatWithSymbol: true,
+    symbol: "Gwei",
+    separator: ",",
+    decimal: ".",
+    precision: 0,
+    pattern: "# !",
+  };
+  document.currency_options = JSON.stringify(currency_options);
+
+  // 7.6 seller_uuid
+  //
+  document.seller_uuid = old_status.seller_uuid;
+
+  // 7.7 seller_details
+  //
+  let seller = document_json.credentialSubject.seller;
+  let seller_details = {};
+  seller_details.organization_name = seller.name;
+  seller_details.organization_tax_id = seller.taxId;
+  seller_details.organization_department = seller.description;
+  seller_details.organization_building = seller.address.streetAddress;
+  seller_details.building = seller.address.addressLocality;
+  seller_details.addressCountry = seller.address.addressCountry;
+  seller_details.addressRegion = seller.address.addressRegion;
+  seller_details.addressCity = seller.address.addressCity;
+
+  document.seller_details = JSON.stringify(seller_details);
+
+  // 7.8 seller_membername
+  //
+  let seller_membername =
+    document_json.credentialSubject.seller.contactPoint.split("@")[0];
+  document.seller_membername = seller_membername;
+
+  // 7.9 buyer_uuid
+  //
+  document.buyer_uuid = old_status.buyer_uuid;
+
+  // 7.10 buyer_details
+  //
+  let buyer = document_json.credentialSubject.buyer;
+  let buyer_details = {};
+  buyer_details.organization_name = buyer.name;
+  buyer_details.organization_tax_id = buyer.taxId;
+  buyer_details.organization_department = buyer.description;
+  buyer_details.organization_building = buyer.address.streetAddress;
+  buyer_details.building = buyer.address.addressLocality;
+  buyer_details.addressCountry = buyer.addressCountry;
+  buyer_details.addressRegion = buyer.addressRegion;
+  buyer_details.addressCity = buyer.addressCity;
+
+  document.buyer_details = JSON.stringify(buyer_details);
+
+  // 7.11 buyer_membername
+  //
+  let buyer_membername =
+    document_json.credentialSubject.buyer.contactPoint.split("@")[0];
+  document.buyer_membername = buyer_membername;
+
+  // 7.12 create_on
+  //
+  document.create_on = status.create_on;
+
+  // 7.13 document_meta
+  //
+  document.document_meta = {};
+
+  let document_meta = {};
+  document_meta.document_number = status.document_number;
+  document_meta.created_on = status.create_on.substr(0, 10);
+  document_meta.taxId = document_json.credentialSubject.seller.taxId;
+  document_meta.due_by = status.due_by;
+
+  document.document_meta = JSON.stringify(document_meta);
+
+  // 7.14 document_body
+  //
+  let document_body = [];
+  let iS = document_json.credentialSubject.itemsShipped;
+  let max_rows = iS.length;
+  for (let i = 0; i < max_rows; i++) {
+    document_body[i] = {};
+
+    document_body[i].date = iS[i].description;
+    document_body[i].desc = iS[i].product.description;
+    document_body[i].price =
+      iS[i].product.productPrice.price +
+      " " +
+      iS[i].product.productPrice.priceCurrency;
+    document_body[i].unit = iS[i].product.sizeOrAmount.unitCode;
+    document_body[i].quan = iS[i].product.sizeOrAmount.value;
+    document_body[i].subtotal =
+      iS[i].lineItemTotalPrice.price +
+      " " +
+      iS[i].lineItemTotalPrice.priceCurrency;
+  }
+  document.document_body = JSON.stringify(document_body);
+
+  // 7.15 document_totals
+  //
+  let document_totals = {};
+  document_totals.subtotal =
+    document_json.credentialSubject.invoiceSubtotal.price +
+    " " +
+    document_json.credentialSubject.invoiceSubtotal.priceCurrency;
+  document_totals.total =
+    document_json.credentialSubject.totalPaymentDue.price +
+    " " +
+    document_json.credentialSubject.totalPaymentDue.priceCurrency;
+
+  document.document_totals = JSON.stringify(document_totals);
+
+  // 8.
+  // Does document_uuid already notexist in the default status table?
+  //
+  const [_8, err8] = await sub.notexist_check(
+    SELLER_DRAFT_STATUS,
+    document_uuid
+  );
+  if (err8) {
+    errno = 8;
+    console.log("Error: " + errno);
+    return res.status(400).json({ err: errno, msg: err8 });
+  }
+
+  // 9.
+  // Does document_uuid already notexist in the default document table?
+  //
+  const [_9, err9] = await sub.notexist_check(
+    SELLER_DRAFT_DOCUMENT,
+    document_uuid
+  );
+  if (err9) {
+    errno = 9;
+    console.log("Error: " + errno);
+    return res.status(400).json({ err: errno, msg: err9 });
+  }
+
+  // 10.
+  // begin Transaction
+  //
+  const [conn, _10] = await tran.connection();
+  await tran.beginTransaction(conn);
+
+  // 11.
+  // Then we go ahead and insert into the draft status
+  //
+
+  const [_11, err11] = await tran.insertStatus(
+    conn,
+    SELLER_DRAFT_STATUS,
+    status
+  );
+
+  if (err11) {
+    errno = 11;
+    insertDraftDocument;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err11, errno));
+  }
+
+  // 12.
+  // And then we need to insert into the draft document
+  //
+  const [_12, err12] = await tran.insertDraftDocument(
+    conn,
+    SELLER_DRAFT_DOCUMENT,
+    document
+  );
+
+  if (err12) {
+    console.log("err12=" + err12);
+    errno = 12;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err12, errno));
+  }
+
+  // 13.
+  // Remove from SELLER_STATUS with docunent_uuid key
+  //
+  const [_13, err13] = await tran.deleteStatus(conn, SELLER_STATUS, old_status);
+
+  if (err13) {
+    errno = 13;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err13, errno));
+  }
+
+  // 14.
+  // Remove from SELLER_DOCUMENT with docunent_uuid key
+  //
+  const [_14, err14] = await tran.deleteDocument(
+    conn,
+    SELLER_DOCUMENT,
+    old_status
+  );
+  if (err14) {
+    errno = 14;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err14, errno));
+  }
+
+  // 15.
+  // Then we go ahead and insert into the archive status
+  //
+
+  old_status.document_folder = "trash";
+  const [_15, err15] = await tran.insertStatus(
+    conn,
+    SELLER_ARCHIVE_STATUS,
+    old_status
+  );
+
+  if (err15) {
+    errno = 15;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err15, errno));
+  }
+
+  // 16.
+  // And then we need to insert into the archive document
+  //
+  const [_16, err16] = await tran.insertDocument(
+    conn,
+    SELLER_ARCHIVE_DOCUMENT,
+    old_status,
+    old_document.document_json
+  );
+
+  if (err16) {
+    errno = 16;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err16, errno));
+  }
+
+  // 17.
+  // Send 'recreate' message to buyer.
+  //
+
+  const [code17, err17] = await to_buyer.recreate(
+    buyer_host,
+    old_status.document_uuid,
+    old_status.seller_uuid
+  );
+
+  if (parseInt(code17) !== 200) {
+    errno = 17;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code17, err17, errno));
+  }
+
+  // 18.
+  // commit
+  //
+  const [_18, err18] = await tran.commit(conn);
+
+  if (err18) {
+    errno = 18;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err18, errno));
+  }
+
+  // 19.
+  //
+  conn.end();
+
+  //console.log("recreate accepted");
+
+  res.json({
+    err: 0,
+    msg: status.document_uuid,
+  });
+
+  let end = Date.now();
+  console.log("/recreate Time: %d ms", end - start);
 });
 
 /*
  * [ Withdraw ]
  * withdraw
  */
-router.post('/withdraw', async function(req, res) {
+router.post("/withdraw", async function (req, res) {
+  let start = Date.now();
 
-	let start = Date.now();
+  const { document_uuid, document_folder } = req.body;
+  const { member_uuid } = req.session.data;
 
-	const { document_uuid , document_folder } = req.body;
-	const { member_uuid } = req.session.data;
+  let errno, code;
 
+  // 1.
+  //
+  const [buyer_uuid, err1] = await sub.getBuyerUuid(
+    SELLER_STATUS,
+    document_uuid,
+    member_uuid
+  );
 
-	let errno , code;
+  if (err1) {
+    console.log("Error 1 status = 400 err=" + err1);
 
-	// 1.
-	//
-	const [ buyer_uuid, err1 ] = await sub.getBuyerUuid(SELLER_STATUS, document_uuid, member_uuid);
+    return res.status(400).json(err1);
+  }
 
-	if(err1) {
-		console.log("Error 1 status = 400 err="+err1);
+  // 2.
+  const [buyer_host, err2] = await sub.getBuyerHost(
+    CONTACTS,
+    member_uuid,
+    buyer_uuid
+  );
 
-		return res.status(400).json(err1);
-	}
+  if (err2) {
+    console.log("Error 2 status = 400 err=" + err2);
+    return res.status(400).json(err2);
+  }
 
+  //3. buyer connect check
+  const [code3, err3] = await to_buyer.connect(
+    buyer_host,
+    member_uuid,
+    buyer_uuid
+  );
 
-	// 2.
-	const [ buyer_host, err2 ] = await sub.getBuyerHost(CONTACTS, member_uuid, buyer_uuid);
+  if (code3 !== 200) {
+    console.log("Error 3 status = 400 code=" + code3);
+    let msg;
+    if (code3 == 500) {
+      msg = { err: "buyer connect check:ECONNRESET" };
+    } else {
+      switch (err3) {
+        case "Not found.":
+          msg = { err: "The destination node cannot be found." };
+          break;
+        default:
+          msg = { err: err3 };
+          break;
+      }
+    }
+    return res.status(400).json(msg);
+  }
 
-	if(err2) {
-		console.log("Error 2 status = 400 err="+err2);
-		return res.status(400).json(err2);
-	}
+  // 4
+  // STATUS
+  // First we go ahead and get the status.
+  //
+  const [old_status, _4] = await sub.getStatus(SELLER_STATUS, document_uuid);
 
+  // Does record exist?
+  if (old_status.document_uuid == null) {
+    console.log("document_uuid is null");
+    errno = 4;
 
-	//3. buyer connect check
-	const [ code3, err3 ] = await to_buyer.connect(buyer_host, member_uuid, buyer_uuid);
+    let msg = { err: errno, msg: document_uuid };
 
-	if(code3 !== 200) {
-		console.log("Error 3 status = 400 code="+code3);
-		let msg;
-		if(code3 == 500) {
-			msg = {"err":"buyer connect check:ECONNRESET"};
-		} else {
-			switch(err3) {
-			case "Not found.":
-				msg = {"err":"The destination node cannot be found."};
-			break;
-			default:
-				msg = {"err":err3};
-			break;
-			}
-		}
-		return res.status(400).json(msg);
-	}
+    return res.status(400).json(msg);
+  }
 
+  // 5.
+  // Does document_uuid already exist in the status table?
+  //
+  const [_5, err5] = await sub.exist_check(SELLER_STATUS, document_uuid);
 
-	// 4 
-	// STATUS
-	// First we go ahead and get the status.
-	//
-	const [ old_status , _4 ] = await sub.getStatus( SELLER_STATUS, document_uuid) ;
+  if (err5) {
+    console.log("Error 5 status = 400 code=" + err5);
+    errno = 5;
+    return res.status(400).json({ err: err5, code: errno });
+  }
 
-	// Does record exist?
-	if(old_status.document_uuid == null) {
-		console.log("document_uuid is null")
-		errno = 4;
+  // 6.
+  // Does document_uuid already exist in the document table?
+  //
+  const [_6, err6] = await sub.exist_check(SELLER_DOCUMENT, document_uuid);
 
-		let msg = { err : errno, msg : document_uuid };
+  if (err6) {
+    console.log("Error 6 status = 400 code=" + err6);
+    errno = 6;
+    return res.status(400).json({ err: err6, code: errno });
+  }
 
-		return res.status(400).json(msg);
-	}
+  // 7.
+  // begin Transaction
+  //
+  const [conn, _7] = await tran.connection();
+  await tran.beginTransaction(conn);
 
+  // 8.
+  // update status
+  //
 
-	// 5.
-	// Does document_uuid already exist in the status table?
-	//
-	const [ _5, err5] = await sub.exist_check( SELLER_STATUS, document_uuid)
+  const [_8, err8] = await tran.setWithdrawSeller(
+    conn,
+    SELLER_STATUS,
+    document_uuid,
+    member_uuid,
+    document_folder
+  );
 
-	if (err5 ) {
-		console.log("Error 5 status = 400 code="+err5);
-		errno = 5;
-		return res.status(400).json({ err : err5, code :errno  });
-	}
+  if (err8) {
+    console.log("Error 8 status = 400 code=" + err8.msg);
+    errno = 8;
+    code = 400;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code, err8, errno));
+  }
 
+  // 9.
+  // Send 'withdraw" message to buyer.
+  //
 
-	// 6.
-	// Does document_uuid already exist in the document table?
-	//
-	const [ _6, err6] = await sub.exist_check( SELLER_DOCUMENT, document_uuid)
+  const [code9, err9] = await to_buyer.withdraw(
+    buyer_host,
+    old_status.document_uuid,
+    old_status.buyer_uuid,
+    document_folder
+  );
 
-	if (err6 ) {
-		console.log("Error 6 status = 400 code="+err6);
-		errno = 6;
-		return res.status(400).json({ err : err6, code :errno  });
-	}
+  if (code9 !== 200) {
+    console.log("Error 9 status = 400 code=" + err9);
+    errno = 9;
+    return res
+      .status(400)
+      .json(tran.rollbackAndReturn(conn, code9, err9, errno));
+  }
 
-	// 7.
-	// begin Transaction
-	//
-	const [ conn , _7 ] = await tran.connection ();
-	await tran.beginTransaction(conn);
+  // 10
+  // commit
+  //
+  const [_10, err10] = await tran.commit(conn);
 
+  if (err10) {
+    console.log("Error 10 status = 400 code=" + err10);
+    errno = 10;
+    code = 400;
+    let msg = tran.rollbackAndReturn(conn, code, err10, errno);
 
-	// 8.  
-	// update status 
-	//
+    // 11.
+    //
+    const [seller_host, err11] = await sub.getSellerHost(
+      CONTACTS,
+      member_uuid,
+      buyer_uuid
+    );
 
-	const [ _8, err8] = await tran.setWithdrawSeller(conn, SELLER_STATUS, document_uuid ,  member_uuid, document_folder);
+    if (err11) {
+      console.log("Error 11 status = 400 err=" + err11);
+      return res.status(400).json(err11);
+    }
 
-	if (err8 ) {
-		console.log("Error 8 status = 400 code="+err8.msg);
-		errno = 8;
-		code = 400;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code, err8, errno));
-	}
+    // 12.
+    //
+    const [code12, err12] = await to_buyer.rollbackReturnToSent(
+      seller_host,
+      buyer_uuid,
+      member_uuid
+    );
 
+    if (code12 !== 200) {
+      console.log("Error 12 code=" + code12 + ":err=" + err12);
+      if (code12 == 500) {
+        msg = { err: "seller connect check:ECONNRESET" };
+      } else {
+        msg = { err: err12 };
+      }
+    }
 
-	// 9. 
-	// Send 'withdraw" message to buyer.
-	//
+    return res.status(400).json(msg);
+  }
 
-	const [ code9, err9 ] = await to_buyer.withdraw(buyer_host, old_status.document_uuid, old_status.buyer_uuid, document_folder);
+  // 13.
+  //
+  conn.end();
 
-	if(code9 !== 200) {
-		console.log("Error 9 status = 400 code="+err9);
-		errno = 9;
-		return res.status(400).json(tran.rollbackAndReturn(conn, code9, err9, errno));
-	}
+  //console.log("/withdraw accepted");
 
+  res.json({
+    err: 0,
+    msg: document_uuid,
+  });
 
-	// 10
-	// commit
-	//
-	const [ _10, err10 ] =	await tran.commit(conn);
-
-	if (err10) {
-		console.log("Error 10 status = 400 code="+err10);
-		errno = 10;
-		code = 400;
-		let msg = tran.rollbackAndReturn(conn, code, err10, errno);
-
-	// 11.
-	//
-		const [ seller_host, err11 ] = await sub.getSellerHost(CONTACTS, member_uuid, buyer_uuid);
-
-		if(err11) {
-			console.log("Error 11 status = 400 err="+err11);
-			return res.status(400).json(err11);
-		}
-
-
-	// 12.
-	//
-		const [ code12, err12 ] = await to_buyer.rollbackReturnToSent(seller_host, buyer_uuid, member_uuid);
-
-		if(code12 !== 200) {
-			console.log("Error 12 code="+code12+":err="+err12);
-			if(code12 == 500) {
-				msg = {"err":"seller connect check:ECONNRESET"};
-			} else {
-				msg = {"err":err12};
-			}
-		}
-
-		return res.status(400).json(msg);
-	}
-
-
-	// 13.
-	//
-   	conn.end();
-
-	//console.log("/withdraw accepted");
-
-	res.json({
-		err : 0,
-		msg : document_uuid
-	});
-
-	let end = Date.now();
-	console.log("/withdraw Time: %d ms", end - start);
-
+  let end = Date.now();
+  console.log("/withdraw Time: %d ms", end - start);
 });

--- a/routes/seller_to_buyer.js
+++ b/routes/seller_to_buyer.js
@@ -88,6 +88,16 @@ async function buyer_sendInvoice(buyer_host, document, status) {
 
 	const url = `${buyer_host}/api/message/buyerToSend`;
 
+	console.log('Sending Invoice to Buyer');
+	console.log(url);
+	
+	console.log('!!! Document !!!');
+	console.log(document);
+	console.log(JSON.parse(document.document_json));
+	
+	console.log('!!! Status !!!');
+	console.log(status);
+
     document.editable = 0;
     status.document_folder = 'sent';
 


### PR DESCRIPTION
This PR changes the handling for sending invoices from the internal `/messages` API to use did-auth `/presentations/available` and `/presentations/submissions`. What surprised me is that it took a not-good-but-acceptable time of 4 seconds for sending to 16 seconds, which is incredibly slow.

With respect to interoperability, I want to allow for Private Invoice to be able to connect and communicate with other applications. But in the case of sending invoices, we can make two assertions:

1. That sending invoices for the purposes of payment will likely to be a Private Invoice or system that emulates the same calls
2. That we only care about the invoice being signed by a contact, and a presentation doesn't add any new functionality

In which case, I think I'll add an option to allow for the original message API to be used.